### PR TITLE
[DPMBE-19] ci : jacoco 테스트 커버리지 측정 , sonar cloud workflow 설정

### DIFF
--- a/.github/workflows/CI_Check.yml
+++ b/.github/workflows/CI_Check.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: spotless check
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck --no-daemon
 
       - name: test and analyze
         env:

--- a/.github/workflows/CI_Check.yml
+++ b/.github/workflows/CI_Check.yml
@@ -44,4 +44,4 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew test sonar --info --stacktrace
+        run: ./gradlew test sonar --info --stacktrace --no-daemon

--- a/.github/workflows/CI_Check.yml
+++ b/.github/workflows/CI_Check.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Kotlin
         uses: actions/setup-java@v3
@@ -21,11 +23,25 @@ jobs:
           kotlin-version: ${{ matrix.kotlin-version }}
           distribution: 'adopt'
 
-      - name: Gradle Build
-        uses: gradle/gradle-build-action@v2
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
-      - name: Execute Gradle build
-        run: ./gradlew build :Whatnow-Api:build
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
 
       - name: spotless check
         run: ./gradlew spotlessCheck
+
+      - name: test and analyze
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test sonar --info --stacktrace

--- a/.github/workflows/develop-branch-test-coverage.yml
+++ b/.github/workflows/develop-branch-test-coverage.yml
@@ -1,0 +1,45 @@
+# 디밸롭 메인 브런치의 총 테스트 커버리지 측정을 위한 ci workflow
+name: develop-branch-test-coverage
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kotlin-version: [ 1.5.31 ]
+        java-version: [ 11 ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Kotlin
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java-version }}
+          kotlin-version: ${{ matrix.kotlin-version }}
+          distribution: 'adopt'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: test and analyze
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test sonar --info --stacktrace --no-daemon

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM adoptopenjdk/openjdk11
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} /app.jar
-ENTRYPOINT ["java","-jar"]
-EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # 13th-6team-server
-66666년만에 환생한 흑마법사 
+66666년만에 환생한 흑마법사
+
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=depromeet_Whatnow-Api&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=depromeet_Whatnow-Api)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=depromeet_Whatnow-Api&metric=coverage)](https://sonarcloud.io/summary/new_code?id=depromeet_Whatnow-Api)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=depromeet_Whatnow-Api&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=depromeet_Whatnow-Api)
+
 
 ## 서비스
 - Whatnow-Api
 - Whatnow-Location
+
+

--- a/Whatnow-Api/settings.gradle.kts
+++ b/Whatnow-Api/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = 'Whatnow-Api'

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnowapi/example/dto/ExampleRequestDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnowapi/example/dto/ExampleRequestDto.kt
@@ -1,0 +1,6 @@
+package com.depromeet.whatnowapi.example.dto
+
+data class ExampleRequestDto(
+    val id: Long,
+    val name: String,
+)

--- a/Whatnow-Domain/Dockerfile
+++ b/Whatnow-Domain/Dockerfile
@@ -1,5 +1,0 @@
-FROM adoptopenjdk/openjdk11
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} /app.jar
-ENTRYPOINT ["java","-jar"]
-EXPOSE 8080

--- a/Whatnow-Domain/settings.gradle.kts
+++ b/Whatnow-Domain/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "Whatnow-Domain"

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClass.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClass.kt
@@ -1,7 +1,7 @@
 package com.depromeet.whatnowdomain.domains.example
 
 class ExampleClass {
-    fun example() : Int{
-        return 1;
+    fun example(): Int {
+        return 1
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClass.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClass.kt
@@ -1,0 +1,7 @@
+package com.depromeet.whatnowdomain.domains.example
+
+class ExampleClass {
+    fun example() : Int{
+        return 1;
+    }
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnowdomain/WhatnowDomainApplicationTests.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnowdomain/WhatnowDomainApplicationTests.kt
@@ -9,5 +9,4 @@ class WhatnowDomainApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClassTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnowdomain/domains/example/ExampleClassTest.kt
@@ -1,0 +1,13 @@
+package com.depromeet.whatnowdomain.domains.example
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ExampleClassTest {
+    private val exampleClass = ExampleClass()
+
+    @Test
+    fun shouldReturn1() {
+        Assertions.assertEquals(1, exampleClass.example())
+    }
+}

--- a/Whatnow-Infrastructure/Dockerfile
+++ b/Whatnow-Infrastructure/Dockerfile
@@ -1,5 +1,0 @@
-FROM adoptopenjdk/openjdk11
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} /app.jar
-ENTRYPOINT ["java","-jar"]
-EXPOSE 8080

--- a/Whatnow-Infrastructure/settings.gradle.kts
+++ b/Whatnow-Infrastructure/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "Whatnow-Infrastructure"

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnowinfrastructure/WhatnowInfrastructureApplicationTests.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnowinfrastructure/WhatnowInfrastructureApplicationTests.kt
@@ -9,5 +9,4 @@ class WhatnowInfrastructureApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }

--- a/Whatnow-Location/settings.gradle.kts
+++ b/Whatnow-Location/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "Whatnow-Location"

--- a/Whatnow-Location/src/test/kotlin/com/depromeet/whatnowlocation/WhatnowLocationApplicationTests.kt
+++ b/Whatnow-Location/src/test/kotlin/com/depromeet/whatnowlocation/WhatnowLocationApplicationTests.kt
@@ -9,5 +9,4 @@ class WhatnowLocationApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,5 +110,11 @@ subprojects{
         )
     }
 
+    sonarqube {
+        properties {
+            property ("sonar.java.binaries", "${buildDir}/classes")
+            property ("sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco.xml")
+        }
+    }
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,27 @@ plugins {
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21" apply false
     kotlin("plugin.jpa") version "1.6.21" apply false
-    id("com.diffplug.spotless") version  "6.18.0"
+    id("com.diffplug.spotless") version  "6.18.0" // spotless
+    id("org.sonarqube") version "3.5.0.2730" // 소나 클라우드
+    id("jacoco")
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_11
+
+sonarqube {
+    properties {
+        property ("sonar.projectKey", "depromeet_Whatnow-Api")
+        property ("sonar.organization", "depromeet-1")
+        property ("sonar.host.url", "https://sonarcloud.io")
+        property ("sonar.sources", "src")
+        property ("sonar.language", "java")
+        property ("sonar.sourceEncoding", "UTF-8")
+        property ("sonar.test.inclusions", "**/*Test.java")
+        property ("sonar.exclusions", "**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java, **/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java")
+        property ("sonar.java.coveragePlugin", "jacoco")
+    }
+}
+
 
 allprojects {
     group = "com.depromeet"
@@ -28,6 +45,7 @@ allprojects {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
@@ -39,11 +57,15 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
     }
 }
 
+
+
 subprojects{
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "org.springframework.boot")
     apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "jacoco" )
+
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-web")
@@ -54,5 +76,13 @@ subprojects{
     }
     tasks.getByName<Jar>("jar") {
         enabled = false
+    }
+
+
+    tasks.test {
+        finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+    }
+    tasks.jacocoTestReport {
+        dependsOn(tasks.test) // tests are required to run before generating the report
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,33 @@ subprojects{
     tasks.test {
         finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
     }
+
+
+
     tasks.jacocoTestReport {
         dependsOn(tasks.test) // tests are required to run before generating the report
+        reports {
+            html.required.set(true) // html 설정
+            csv.required.set(true) // csv 설정
+            xml.required.set(true)
+            xml.outputLocation.set(File("${buildDir}/reports/jacoco.xml"))
+        }
+
+        classDirectories.setFrom(
+                files(classDirectories.files.map {
+                    fileTree(it) { // jacoco file 테스트 커버리지 측정안할 목록
+                        exclude("**/*Application*",
+                                "**/*Config*",
+                                "**/*Dto*",
+                                "**/*Request*",
+                                "**/*Response*",
+                                "**/*Interceptor*",
+                                "**/*Exception*" ,
+                                "**/Q*") // Query Dsl 용이긴하나 Q로 시작하는 다른 클래스를 뺄 위험이 있음.
+                    }
+                })
+        )
     }
+
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,10 @@ sonarqube {
         property ("sonar.organization", "depromeet-1")
         property ("sonar.host.url", "https://sonarcloud.io")
         property ("sonar.sources", "src")
-        property ("sonar.language", "java")
+        property ("sonar.language", "Kotlin")
         property ("sonar.sourceEncoding", "UTF-8")
         property ("sonar.test.inclusions", "**/*Test.java")
-        property ("sonar.exclusions", "**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java, **/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java")
+        property ("sonar.exclusions", "**/test/**, **/Q*.kt, **/*Doc*.kt, **/resources/** ,**/*Application*.kt , **/*Config*.kt, **/*Dto*.kt, **/*Request*.kt, **/*Response*.kt ,**/*Exception*.kt ,**/*ErrorCode*.kt")
         property ("sonar.java.coveragePlugin", "jacoco")
     }
 }


### PR DESCRIPTION
## 개요
-DPMBE-19

## 작업사항
- 자코코, 소나클라우드 세팅했습니다.
- jacoco로는 테스트 커버리지 측정
- 소나클라우드는 정적 검사

- 소나클라우드 연동방식은 ci 로 연동했습니다.  ( 자동검사 안함 )
- jacoco 테스트 커버리지 xml 결과를 소나클라우드로 전송하면 테스트 커버리지 결과까지
- 소나클라우드가 각 피알 마다 댓글로 테스트 결과 알려줍니다.

## 변경로직
- 각 모듈별 불필요 파일 삭제했습니다. 도커파일같은거