### PR TITLE
[DPMBE-22] feat : kakao oauth 관련 요청 feign 설정

### DIFF
--- a/Whatnow-Api/Dockerfile
+++ b/Whatnow-Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-alpine
+FROM adoptopenjdk/openjdk11
 
 EXPOSE 8080
 

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/user/usecase/RegisterUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/user/usecase/RegisterUserUseCase.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.user.usecase
 
-import com.depromeet.whatnow.api.TestFeignClient
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.service.UserDomainService
 import org.springframework.stereotype.Service
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service
 @Service // TODO : UseCase annotation 을 커스텀 하게 만들고싶은데 위치를 어디로 줘야할지? 커먼 레이어가없음
 class RegisterUserUseCase(
     val userDomainService: UserDomainService,
-    val testFeignClient: TestFeignClient,
 ) {
     fun execute(): User {
         return userDomainService.registerUser()

--- a/Whatnow-Infrastructure/build.gradle.kts
+++ b/Whatnow-Infrastructure/build.gradle.kts
@@ -5,6 +5,9 @@ dependencies{
     api ("io.github.openfeign:feign-httpclient:12.1")
     api ("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
     api ("io.github.openfeign:feign-jackson:12.1")
+
+    testImplementation ("org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.1.5")
+    testImplementation ("org.springframework.cloud:spring-cloud-contract-wiremock:3.1.5")
 }
 
 

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
@@ -1,0 +1,18 @@
+package com.depromeet.whatnow.api
+
+import com.depromeet.whatnow.api.dto.KakaoInformationResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+// TODO : 에러 정책 확립되면 feign 에러 config 하기 , configuration = [KakaoInfoConfig::class]
+@FeignClient(name = "KakaoInfoClient", url = "https://kapi.kakao.com")
+interface KakaoInfoClient {
+    @GetMapping("/v2/user/me")
+    fun kakaoUserInfo(@RequestHeader("Authorization") accessToken: String): KakaoInformationResponse
+
+    // TODO : 회원탈퇴
+//    @PostMapping(path = ["/v1/user/unlink"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+//    fun unlinkUser(
+//            @RequestHeader("Authorization") adminKey: String, unlinkKaKaoTarget: UnlinkKaKaoTarget)
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 
 // TODO : 에러 정책 확립되면 feign 에러 config 하기 , configuration = [KakaoInfoConfig::class]
-@FeignClient(name = "KakaoInfoClient", url = "https://kapi.kakao.com")
+@FeignClient(name = "KakaoInfoClient", url = "\${feign.kakao.info}")
 interface KakaoInfoClient {
     @GetMapping("/v2/user/me")
     fun kakaoUserInfo(@RequestHeader("Authorization") accessToken: String): KakaoInformationResponse

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
@@ -1,0 +1,24 @@
+package com.depromeet.whatnow.api
+
+import com.depromeet.whatnow.api.dto.KakaoTokenResponse
+import com.depromeet.whatnow.api.dto.OIDCPublicKeysResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+
+// TODO : , configuration = [KakaoKauthConfig::class] 애러정책 확립후 클라이언트 설정 들어가기
+@FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
+interface KakaoOauthClient {
+    @PostMapping("/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
+    fun kakaoAuth(
+        @PathVariable("CLIENT_ID") clientId: String,
+        @PathVariable("REDIRECT_URI") redirectUri: String,
+        @PathVariable("CODE") code: String,
+        @PathVariable("CLIENT_SECRET") client_secret: String,
+    ): KakaoTokenResponse
+
+    // TODO : NEED 캐싱
+    @GetMapping("/.well-known/jwks.json")
+    fun kakaoOIDCOpenKeys(): OIDCPublicKeysResponse
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 
 // TODO : , configuration = [KakaoKauthConfig::class] 애러정책 확립후 클라이언트 설정 들어가기
-@FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
+@FeignClient(name = "KakaoAuthClient", url = "\${feign.kakao.oauth}")
 interface KakaoOauthClient {
     @PostMapping("/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
     fun kakaoAuth(

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/TestFeignClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/TestFeignClient.kt
@@ -1,6 +1,0 @@
-package com.depromeet.whatnow.api
-
-import org.springframework.cloud.openfeign.FeignClient
-
-@FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
-interface TestFeignClient

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
@@ -1,0 +1,31 @@
+package com.depromeet.whatnow.api.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class KakaoInformationResponse(
+    val properties: Properties,
+    val id: String,
+    val kakaoAccount: KakaoAccount,
+) {
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+    data class Properties(
+        val nickname: String,
+    )
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+    data class KakaoAccount(
+        val profile: Profile,
+        val email: String,
+        val phoneNumber: String,
+        val name: String,
+    ) {
+
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+        data class Profile(
+            val profileImageUrl: String,
+        )
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class KakaoInformationResponse(
-    val properties: Properties,
+//    val properties: Properties,
     val id: String,
     val kakaoAccount: KakaoAccount,
 ) {
 
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-    data class Properties(
-        val nickname: String,
-    )
+//    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+//    data class Properties(
+//        val nickname: String,
+//    )
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class KakaoAccount(
@@ -26,6 +26,7 @@ data class KakaoInformationResponse(
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
         data class Profile(
             val profileImageUrl: String,
+            val isDefaultImage: Boolean,
         )
     }
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
@@ -3,7 +3,6 @@ package com.depromeet.whatnow.api.dto
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
-
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class KakaoTokenResponse(
     val accessToken: String,

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
@@ -1,5 +1,10 @@
 package com.depromeet.whatnow.api.dto
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class KakaoTokenResponse(
     val accessToken: String,
     val refreshToken: String,

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoTokenResponse.kt
@@ -1,0 +1,7 @@
+package com.depromeet.whatnow.api.dto
+
+data class KakaoTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val idToken: String,
+)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/OIDCPublicKeyDto.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/OIDCPublicKeyDto.kt
@@ -1,0 +1,10 @@
+package com.depromeet.whatnow.api.dto
+
+data class OIDCPublicKeyDto(
+
+    val kid: String,
+    val alg: String,
+    val use: String,
+    val n: String,
+    val e: String,
+)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/OIDCPublicKeysResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/OIDCPublicKeysResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.dto
+
+data class OIDCPublicKeysResponse(
+    val keys: List<OIDCPublicKeyDto>,
+)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/EnableConfigProperties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/EnableConfigProperties.kt
@@ -1,0 +1,8 @@
+package com.depromeet.whatnow.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@EnableConfigurationProperties(OauthProperties::class)
+@Configuration
+class EnableConfigProperties

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/FeignCommonConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/FeignCommonConfig.kt
@@ -16,23 +16,24 @@ import org.springframework.context.annotation.Configuration
 @EnableFeignClients(basePackageClasses = [BaseFeignClientPackage::class])
 class FeignCommonConfig {
 
-    @Bean
-    fun feignDecoder(): Decoder {
-        return JacksonDecoder(customObjectMapper())
-    }
-
-    /**
-     * 타임관련 유닛 해석을 위한 디코더 추가
-     * @return
-     */
-    fun customObjectMapper(): ObjectMapper {
-        val objectMapper = ObjectMapper()
-        objectMapper.registerModule(JavaTimeModule())
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
-        return objectMapper
-    }
+    // 코틀린으로 잭슨 설정이 잘 안먹힘... 일단 패스!
+//    @Bean
+//    fun feignDecoder(): Decoder {
+//        return JacksonDecoder(customObjectMapper())
+//    }
+//
+//    /**
+//     * 타임관련 유닛 해석을 위한 디코더 추가
+//     * @return
+//     */
+//    fun customObjectMapper(): ObjectMapper {
+//        val objectMapper = ObjectMapper()
+//        objectMapper.registerModule(JavaTimeModule())
+//        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+//        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+//        objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
+//        return objectMapper
+//    }
 
     @Bean
     fun feignLoggerLevel(): Logger.Level {

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/FeignCommonConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/FeignCommonConfig.kt
@@ -1,13 +1,7 @@
 package com.depromeet.whatnow.config
 
 import com.depromeet.whatnow.api.BaseFeignClientPackage
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import feign.Logger
-import feign.codec.Decoder
-import feign.jackson.JacksonDecoder
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
@@ -1,0 +1,18 @@
+package com.depromeet.whatnow.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(prefix = "oauth")
+@ConstructorBinding
+data class OauthProperties(
+    val kakao: OAuthSecret,
+) {
+    data class OAuthSecret(
+        val baseUrl: String,
+        val clientId: String,
+        val clientSecret: String,
+        val redirectUrl: String,
+        val appId: String,
+    )
+}

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -13,6 +13,14 @@ spring:
     port: ${REDIS_PORT:6379}
     password: ${REDIS_PASSWORD:}
 
+oauth:
+  kakao:
+    base-url: ${KAKAO_BASE_URL}
+    client-id: ${KAKAO_CLIENT}
+    client-secret: ${KAKAO_SECRET}
+    redirect-url: ${KAKAO_REDIRECT}
+    app-id: ${KAKAO_APP_ID:default}
+    admin-key: ${KAKAO_ADMIN_KEY}
 #feign:
 #  toss:
 #    url : https://api.tosspayments.com

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -21,9 +21,10 @@ oauth:
     redirect-url: ${KAKAO_REDIRECT}
     app-id: ${KAKAO_APP_ID:default}
     admin-key: ${KAKAO_ADMIN_KEY}
-#feign:
-#  toss:
-#    url : https://api.tosspayments.com
+feign:
+  kakao:
+    info : https://kapi.kakao.com
+    oauth : https://kauth.kakao.com
 #ncp:
 #  service-id: ${NCP_SERVICE_ID:}
 #  access-key: ${NCP_ACCESS_KEY:}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/WhatnowInfrastructureApplicationTests.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/WhatnowInfrastructureApplicationTests.kt
@@ -1,9 +1,9 @@
 package com.depromeet.whatnow
 
+import com.depromeet.whatnow.config.InfraIntegrateSpringBootTest
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
+@InfraIntegrateSpringBootTest
 class WhatnowInfrastructureApplicationTests {
 
     @Test

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoInfoClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoInfoClientTest.kt
@@ -1,0 +1,47 @@
+package com.depromeet.whatnow.api
+
+import com.depromeet.whatnow.config.InfraIntegrateProfileResolver
+import com.depromeet.whatnow.config.InfraIntegrateTestConfig
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import org.springframework.util.ResourceUtils
+import java.nio.file.Files
+
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [InfraIntegrateTestConfig::class])
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver::class)
+@TestPropertySource(properties = ["feign.kakao.info=http://localhost:\${wiremock.server.port}"])
+class KakaoInfoClientTest {
+    @Autowired lateinit var kakaoInfoClient: KakaoInfoClient
+
+    @Test
+    fun `카카오 유저 정보 요청이 올바르게 파싱되어야한다`() {
+        val file = ResourceUtils.getFile("classpath:payload/oauth-user-info-response.json").toPath()
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlPathEqualTo("/v2/user/me"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(
+                            "Content-Type",
+                            MediaType.APPLICATION_JSON_VALUE,
+                        )
+                        .withBody(Files.readAllBytes(file)),
+                ),
+        )
+        var response = kakaoInfoClient.kakaoUserInfo("accessToken")
+        assertEquals(response.kakaoAccount.email, "sample@sample.com")
+        assertEquals(response.kakaoAccount.profile.profileImageUrl, "http://yyy.kakao.com/dn/.../img_640x640.jpg")
+        assertEquals(response.kakaoAccount.profile.isDefaultImage, false)
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -1,0 +1,48 @@
+package com.depromeet.whatnow.api
+
+import com.depromeet.whatnow.config.InfraIntegrateProfileResolver
+import com.depromeet.whatnow.config.InfraIntegrateTestConfig
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import org.springframework.util.ResourceUtils
+import java.io.IOException
+import java.nio.file.Files
+import java.time.LocalDate
+
+
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [InfraIntegrateTestConfig::class])
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver::class)
+@TestPropertySource(properties = ["feign.kakao.oauth=http://localhost:\${wiremock.server.port}"])
+class KakaoOauthClientTest {
+    @Autowired lateinit var kakaoOauthClient: KakaoOauthClient
+
+
+    @Test
+    @Throws(IOException::class)
+    fun `Oauth 토큰 요청이 올바르게 파싱되어야한다`() {
+        val file = ResourceUtils.getFile("classpath:payload/oauth-token-response.json").toPath()
+        WireMock.stubFor(
+                WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(HttpStatus.OK.value())
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(file))))
+        var response = kakaoOauthClient.kakaoAuth("CLIENT_ID","REDIRECT_URI","CODE","CLIENT_SECRET");
+        assertEquals( response.idToken, "idToken")
+        assertEquals( response.accessToken, "accessToken")
+        assertEquals( response.refreshToken, "refreshToken")
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -14,10 +14,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.util.ResourceUtils
-import java.io.IOException
 import java.nio.file.Files
-import java.time.LocalDate
-
 
 @ContextConfiguration
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [InfraIntegrateTestConfig::class])
@@ -27,38 +24,44 @@ import java.time.LocalDate
 class KakaoOauthClientTest {
     @Autowired lateinit var kakaoOauthClient: KakaoOauthClient
 
-
     @Test
-    fun `Oauth 토큰 요청이 올바르게 파싱되어야한다`() {
+    fun `카카오 Oauth 토큰 요청이 올바르게 파싱되어야한다`() {
         val file = ResourceUtils.getFile("classpath:payload/oauth-token-response.json").toPath()
         WireMock.stubFor(
-                WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
-                        .willReturn(
-                                WireMock.aResponse()
-                                        .withStatus(HttpStatus.OK.value())
-                                        .withHeader(
-                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                                        .withBody(Files.readAllBytes(file))))
-        var response = kakaoOauthClient.kakaoAuth("CLIENT_ID","REDIRECT_URI","CODE","CLIENT_SECRET");
-        assertEquals( response.idToken, "idToken")
-        assertEquals( response.accessToken, "accessToken")
-        assertEquals( response.refreshToken, "refreshToken")
+            WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(
+                            "Content-Type",
+                            MediaType.APPLICATION_JSON_VALUE,
+                        )
+                        .withBody(Files.readAllBytes(file)),
+                ),
+        )
+        var response = kakaoOauthClient.kakaoAuth("CLIENT_ID", "REDIRECT_URI", "CODE", "CLIENT_SECRET")
+        assertEquals(response.idToken, "idToken")
+        assertEquals(response.accessToken, "accessToken")
+        assertEquals(response.refreshToken, "refreshToken")
     }
 
-
     @Test
-    fun `OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
+    fun `카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
         val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
         WireMock.stubFor(
-                WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
-                        .willReturn(
-                                WireMock.aResponse()
-                                        .withStatus(HttpStatus.OK.value())
-                                        .withHeader(
-                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                                        .withBody(Files.readAllBytes(file))))
-        var response = kakaoOauthClient.kakaoOIDCOpenKeys();
-        assertEquals( response.keys[0].kid, "kid1")
-        assertEquals( response.keys[1].kid, "kid2")
+            WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(
+                            "Content-Type",
+                            MediaType.APPLICATION_JSON_VALUE,
+                        )
+                        .withBody(Files.readAllBytes(file)),
+                ),
+        )
+        var response = kakaoOauthClient.kakaoOIDCOpenKeys()
+        assertEquals(response.keys[0].kid, "kid1")
+        assertEquals(response.keys[1].kid, "kid2")
     }
 }

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -29,7 +29,6 @@ class KakaoOauthClientTest {
 
 
     @Test
-    @Throws(IOException::class)
     fun `Oauth 토큰 요청이 올바르게 파싱되어야한다`() {
         val file = ResourceUtils.getFile("classpath:payload/oauth-token-response.json").toPath()
         WireMock.stubFor(
@@ -44,5 +43,22 @@ class KakaoOauthClientTest {
         assertEquals( response.idToken, "idToken")
         assertEquals( response.accessToken, "accessToken")
         assertEquals( response.refreshToken, "refreshToken")
+    }
+
+
+    @Test
+    fun `OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
+        val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
+        WireMock.stubFor(
+                WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(HttpStatus.OK.value())
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(file))))
+        var response = kakaoOauthClient.kakaoOIDCOpenKeys();
+        assertEquals( response.keys[0].kid, "kid1")
+        assertEquals( response.keys[1].kid, "kid2")
     }
 }

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateProfileResolver.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateProfileResolver.kt
@@ -1,0 +1,10 @@
+package com.depromeet.whatnow.config
+
+import org.springframework.test.context.ActiveProfilesResolver
+
+class InfraIntegrateProfileResolver : ActiveProfilesResolver {
+
+    override fun resolve(testClass: Class<*>): Array<String> {
+        return arrayOf("infrastructure")
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateSpringBootTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateSpringBootTest.kt
@@ -1,0 +1,15 @@
+package com.depromeet.whatnow.config
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.lang.annotation.Documented
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+/** 도메인 모듈의 통합테스트의 편의성을 위해서 만든 어노테이션 -이찬진  */
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(classes = [InfraIntegrateTestConfig::class])
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver::class)
+@Documented
+annotation class InfraIntegrateSpringBootTest

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateTestConfig.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/InfraIntegrateTestConfig.kt
@@ -1,0 +1,9 @@
+package com.depromeet.whatnow.config
+
+import com.depromeet.whatnow.WhatnowInfrastructureApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ComponentScan(basePackageClasses = [WhatnowInfrastructureApplication::class])
+class InfraIntegrateTestConfig

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/OauthPropertiesTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/OauthPropertiesTest.kt
@@ -1,0 +1,15 @@
+package com.depromeet.whatnow.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@InfraIntegrateSpringBootTest
+class OauthPropertiesTest {
+    @Autowired lateinit var oauthProperties: OauthProperties
+
+    @Test
+    fun `oauth 프로퍼티가 제대로 init 되어야한다`() {
+        assertEquals(oauthProperties.kakao.appId, "default")
+    }
+}

--- a/Whatnow-Infrastructure/src/test/resources/payload/oauth-oidc-public-key-response.json
+++ b/Whatnow-Infrastructure/src/test/resources/payload/oauth-oidc-public-key-response.json
@@ -1,0 +1,19 @@
+{
+  "keys": [
+    {
+      "kid": "kid1",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n" : "n1",
+      "e": "e1"
+    }, {
+      "kid": "kid2",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n" : "n2",
+      "e": "e2"
+    }
+  ]
+}

--- a/Whatnow-Infrastructure/src/test/resources/payload/oauth-token-response.json
+++ b/Whatnow-Infrastructure/src/test/resources/payload/oauth-token-response.json
@@ -1,0 +1,9 @@
+{
+  "token_type": "bearer",
+  "access_token": "accessToken",
+  "id_token": "idToken",
+  "expires_in": 1000,
+  "refresh_token": "refreshToken",
+  "refresh_token_expires_in": 1000,
+  "scope": "profile_image openid profile_nickname"
+}

--- a/Whatnow-Infrastructure/src/test/resources/payload/oauth-user-info-response.json
+++ b/Whatnow-Infrastructure/src/test/resources/payload/oauth-user-info-response.json
@@ -1,0 +1,34 @@
+{
+  "id":123456789,
+  "connected_at": "2022-04-11T01:45:28Z",
+  "kakao_account": {
+    "profile_nickname_needs_agreement": false,
+    "profile_image_needs_agreement": false,
+    "profile": {
+      "nickname": "홍길동",
+      "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+      "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+      "is_default_image":false
+    },
+    "name_needs_agreement":false,
+    "name":"홍길동",
+    "email_needs_agreement":false,
+    "is_email_valid": true,
+    "is_email_verified": true,
+    "email": "sample@sample.com",
+    "age_range_needs_agreement":false,
+    "age_range":"20~29",
+    "birthyear_needs_agreement": false,
+    "birthyear": "2002",
+    "birthday_needs_agreement":false,
+    "birthday":"1130",
+    "birthday_type":"SOLAR",
+    "gender_needs_agreement":false,
+    "gender":"female",
+    "phone_number_needs_agreement": false,
+    "phone_number": "+82 010-1234-5678",
+    "ci_needs_agreement": false,
+    "ci": "${CI}",
+    "ci_authenticated_at": "2019-03-11T11:25:22Z"
+  }
+}

--- a/Whatnow-Location/Dockerfile
+++ b/Whatnow-Location/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-alpine
+FROM adoptopenjdk/openjdk11
 
 EXPOSE 8080
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,14 +73,13 @@ subprojects{
     apply(plugin = "jacoco" )
 
 
-
-
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-web")
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+        annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     }
     tasks.getByName<Jar>("jar") {
         enabled = false


### PR DESCRIPTION
## 개요
- DPMBE-22

## 작업사항
- 카카오 oauth 시 필요한 feign 클라이언트를 설정했습니다.
- wiremock 도입해서 파싱 제대로 되는지 테스트를 했습니다.
- wiremock 관련 레퍼런스[ ( 제 블로그 )](https://devnm.tistory.com/34)

- 카카오 oauth api 세개 목록화 , 테스트 했습니다.
- oauth 토큰 요청
- oidc 공개키 요청
- 유저정보 보기 요청


### 해야하는것
 - 에러 정책 수립이후 feign Error decoder 설정
 - 레디스 커넥션 이후 oidc 공개키 요청 캐싱 처리
 - 회원 탈퇴용 api 추가

## 변경로직
- 내용을 적어주세요.