### PR TITLE
[DPMBE-27] feat : 공통응답 어드바이스 추가

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponse.kt
@@ -2,7 +2,7 @@ package com.depromeet.whatnow.config.response
 
 import java.time.LocalDateTime
 
-class SuccessResponse(private val status: Int, private val data: Any?) {
-    private val success = true
-    private val timeStamp: LocalDateTime = LocalDateTime.now()
+data class SuccessResponse(val status: Int, val data: Any?) {
+    val success = true
+    val timeStamp: LocalDateTime = LocalDateTime.now()
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponse.kt
@@ -1,0 +1,8 @@
+package com.depromeet.whatnow.config.response
+
+import java.time.LocalDateTime
+
+class SuccessResponse(private val status: Int, private val data: Any?) {
+    private val success = true
+    private val timeStamp: LocalDateTime = LocalDateTime.now()
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
@@ -20,7 +20,9 @@ class SuccessResponseAdvice : ResponseBodyAdvice<Any?> {
         val servletResponse = (response as ServletServerHttpResponse).servletResponse
         val httpStatus = HttpStatus.resolve(servletResponse.status)!!
         return if (httpStatus.is2xxSuccessful) {
-            SuccessResponse(httpStatus.value(), body)
-        } else body
+            SuccessResponse(servletResponse.status, body)
+        } else {
+            body
+        }
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
@@ -20,7 +20,7 @@ class SuccessResponseAdvice : ResponseBodyAdvice<Any?> {
         val servletResponse = (response as ServletServerHttpResponse).servletResponse
         val httpStatus = HttpStatus.resolve(servletResponse.status)!!
         return if (httpStatus.is2xxSuccessful) {
-            SuccessResponse(httpStatus, body)
+            SuccessResponse(httpStatus.value(), body)
         } else body
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/response/SuccessResponseAdvice.kt
@@ -1,0 +1,26 @@
+package com.depromeet.whatnow.config.response
+
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpResponse
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@RestControllerAdvice(basePackages = ["com.depromeet"])
+class SuccessResponseAdvice : ResponseBodyAdvice<Any?> {
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {
+        return true
+    }
+
+    override fun beforeBodyWrite(body: Any?, returnType: MethodParameter, selectedContentType: MediaType, selectedConverterType: Class<out HttpMessageConverter<*>>, request: ServerHttpRequest, response: ServerHttpResponse): Any? {
+        val servletResponse = (response as ServletServerHttpResponse).servletResponse
+        val httpStatus = HttpStatus.resolve(servletResponse.status)!!
+        return if (httpStatus.is2xxSuccessful) {
+            SuccessResponse(httpStatus, body)
+        } else body
+    }
+}


### PR DESCRIPTION
## 개요
- close #9 

## 작업사항
- 공통 응답 어드바이스를 만들었습니다.

모르고...
응답 디티오에 
```kotlin
data class SuccessResponse(private val status ... 
```
위처럼 private 설정했다가 응답값이 없길래 뭐지하니깐..
자바 기준 Getter가 없으면 
값 못꺼내오니깐 그런거였네요..

접근지시어 없앴습니다 ㅋㅋ 깜박했구만...

```json
{
  "status": 200,
  "data": {
    "nickname": "테스트",
    "profileImg": "테스트",
    "isDefaultImg": false,
    "lastLogin": "2023-05-12T01:16:40.33097",
    "fcmToken": "",
    "status": "NORMAL",
    "id": 1,
    "createdAt": "2023-05-12T01:16:40.330991",
    "updatedAt": "2023-05-12T01:16:40.330994",
    "oauthProfile": {
      "oauthId": "테스트",
      "oauthProvider": "KAKAO"
    }
  },
  "success": true,
  "timeStamp": "2023-05-12T01:16:45.732241"
}
```

위처럼 응답포맷 만들었습니다.

## 변경로직
- 내용을 적어주세요.