### PR TITLE
[DPMBE-25] feat : 레디스 캐시 처리용 설정 및 적용

### DIFF
--- a/.github/workflows/CI_Check.yml
+++ b/.github/workflows/CI_Check.yml
@@ -37,6 +37,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Start containers  # test 돌릴때 레디스 필요
+        run: docker-compose up -d
+
       - name: spotless check
         run: ./gradlew spotlessCheck --no-daemon
 

--- a/.github/workflows/develop-branch-test-coverage.yml
+++ b/.github/workflows/develop-branch-test-coverage.yml
@@ -38,6 +38,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Start containers  # test 돌릴때 레디스 필요
+        run: docker-compose up -d
+
       - name: test and analyze
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Whatnow-Infrastructure/build.gradle.kts
+++ b/Whatnow-Infrastructure/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies{
     api ("io.github.openfeign:feign-httpclient:12.1")
     api ("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
     api ("io.github.openfeign:feign-jackson:12.1")
+    api ("org.springframework.boot:spring-boot-starter-data-redis")
 
     testImplementation ("org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.1.5")
     testImplementation ("org.springframework.cloud:spring-cloud-contract-wiremock:3.1.5")

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
@@ -20,6 +20,6 @@ interface KakaoOauthClient {
     ): KakaoTokenResponse
 
     @GetMapping("/.well-known/jwks.json")
-    @Cacheable(cacheNames = ["KakaoOICD"], cacheManager = "oidcCacheManager")
+    @Cacheable(cacheNames = ["KakaoOIDC"], cacheManager = "oidcCacheManager")
     fun kakaoOIDCOpenKeys(): OIDCPublicKeysResponse
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
@@ -2,6 +2,7 @@ package com.depromeet.whatnow.api
 
 import com.depromeet.whatnow.api.dto.KakaoTokenResponse
 import com.depromeet.whatnow.api.dto.OIDCPublicKeysResponse
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +19,7 @@ interface KakaoOauthClient {
         @PathVariable("CLIENT_SECRET") client_secret: String,
     ): KakaoTokenResponse
 
-    // TODO : NEED 캐싱
     @GetMapping("/.well-known/jwks.json")
+    @Cacheable(cacheNames = ["KakaoOICD"], cacheManager = "oidcCacheManager")
     fun kakaoOIDCOpenKeys(): OIDCPublicKeysResponse
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/feign/FeignCommonConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/feign/FeignCommonConfig.kt
@@ -1,4 +1,4 @@
-package com.depromeet.whatnow.config
+package com.depromeet.whatnow.config.feign
 
 import com.depromeet.whatnow.api.BaseFeignClientPackage
 import feign.Logger

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
@@ -1,0 +1,37 @@
+package com.depromeet.whatnow.config.redis
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@EnableCaching
+@Configuration
+class RedisCacheConfig {
+
+    @Bean
+    fun oidcCacheManager(cf: RedisConnectionFactory): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer(),
+                ),
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer(),
+                ),
+            )
+            .entryTtl(Duration.ofDays(7L))
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisConfig.kt
@@ -1,0 +1,37 @@
+package com.depromeet.whatnow.config.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+import java.time.Duration
+
+@EnableRedisRepositories(basePackages = ["com.depromeet"], enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@Configuration
+class RedisConfig(
+    @Value("\${spring.redis.host}")
+    private val redisHost: String,
+
+    @Value("\${spring.redis.port}")
+    private val redisPort: Int,
+
+    @Value("\${spring.redis.password}")
+    private val redisPassword: String,
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val redisConfig = RedisStandaloneConfiguration(redisHost, redisPort)
+        if (redisPassword.isNotBlank()) redisConfig.setPassword(redisPassword)
+        val clientConfig: LettuceClientConfiguration = LettuceClientConfiguration.builder()
+            .commandTimeout(Duration.ofSeconds(1))
+            .shutdownTimeout(Duration.ZERO)
+            .build()
+        return LettuceConnectionFactory(redisConfig, clientConfig)
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,12 @@ services:
       - "6379:6379"
     environment:
       - TZ=Asia/Seoul
-  rabbit-mq:
-    image: "whatnow2023/rabbitmq-ttl:3.11"
-    environment:
-      - RABBITMQ_USER=guest
-      - RABBITMQ_PASSWORD=guest
-      - TZ=Asia/Seoul
-    ports:
-      - "5672:5672" # Default Port
-      - "15672:15672" # For UI
+#  rabbit-mq:  아직 필요없어서 잠깐 꺼둘게용
+#    image: "whatnow2023/rabbitmq-ttl:3.11"
+#    environment:
+#      - RABBITMQ_USER=guest
+#      - RABBITMQ_PASSWORD=guest
+#      - TZ=Asia/Seoul
+#    ports:
+#      - "5672:5672" # Default Port
+#      - "15672:15672" # For UI


### PR DESCRIPTION
## 개요
- close #11 

## 작업사항
- 캐시 처리를 위해서 레디스 커넥션 만들었습니다.
- 테스트 성공하기 위해서 workflow에 레디스 돌리는 명령어 넣었구요
- 캐시처리말고도 data-redis 로 entity 형식으로 jwt refreshToken 관리도 가능합니당.
- feign 에서도 chachable 어노테이션으로 oicd 공개키 요청 보내기 전에 캐싱처리할 수 있습니다. ( 카카오에서 매번 보내지 말라는 부분 )

## 변경로직
- 내용을 적어주세요.