### PR TITLE
[DPMBE-24] feat : redisson 기반 분산락 AOP를 적용한다

### DIFF
--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonCallNewTransaction.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonCallNewTransaction.kt
@@ -14,7 +14,7 @@ class RedissonCallNewTransaction {
     // leaseTime 보다 트랜잭션 타임아웃을 작게 설정
     // leastTimeOut 발생전에 rollback 시키기 위함
     @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 9)
-    fun proceed(joinPoint: ProceedingJoinPoint): Any {
+    fun proceed(joinPoint: ProceedingJoinPoint): Any? {
         return joinPoint.proceed()
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonCallNewTransaction.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonCallNewTransaction.kt
@@ -1,0 +1,20 @@
+package com.depromeet.whatnow.common.aop.lock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class RedissonCallNewTransaction {
+    // 다른 트랜잭션이 걸린서비스가 해당 조인포인트(메서드를) 호출하더라도
+    // 새로운 트랜잭션이 보장되어야합니다.
+    // 락을 잡기전에 트랜잭션이 시작한건 무의미 하므로,
+
+    // leaseTime 보다 트랜잭션 타임아웃을 작게 설정
+    // leastTimeOut 발생전에 rollback 시키기 위함
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 9)
+    fun proceed(joinPoint: ProceedingJoinPoint): Any {
+        return joinPoint.proceed()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLock.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLock.kt
@@ -1,0 +1,13 @@
+package com.depromeet.whatnow.common.aop.lock
+
+import java.util.concurrent.TimeUnit
+
+@Target
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RedissonLock(
+    val identifier: String,
+    val lockName: String,
+    val waitTime: Long = 30L,
+    val leaseTime: Long = 10L,
+    val timeUnit: TimeUnit = TimeUnit.SECONDS,
+)

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLock.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLock.kt
@@ -2,7 +2,7 @@ package com.depromeet.whatnow.common.aop.lock
 
 import java.util.concurrent.TimeUnit
 
-@Target
+@Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class RedissonLock(
     val identifier: String,

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
@@ -1,0 +1,62 @@
+package com.depromeet.whatnow.common.aop.lock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RedissonClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Component
+import org.springframework.transaction.TransactionTimedOutException
+
+@Aspect
+@Component
+@ConditionalOnExpression("\${ableRedissonLock:true}")
+class RedissonLockAop(
+    private val redissonClient: RedissonClient,
+    private val redissonCallNewTransaction: RedissonCallNewTransaction,
+) {
+
+    @Around("@annotation(com.depromeet.whatnow.common.aop.lock.RedissonLock)")
+    fun lock(joinPoint: ProceedingJoinPoint): Any {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val redissonLock = method.getAnnotation(RedissonLock::class.java)
+        val baseKey: String = redissonLock.lockName
+        val dynamicKey = getDynamicKeyFromMethodArg(signature.parameterNames, joinPoint.args, redissonLock.identifier)
+
+        val rLock = redissonClient.getLock("$baseKey:$dynamicKey")
+
+        try {
+            val available = rLock.tryLock(redissonLock.waitTime, redissonLock.leaseTime, redissonLock.timeUnit)
+            if (!available) {
+                throw Exception("에러정책 이후 변할 예정")
+            }
+
+            return redissonCallNewTransaction
+                .proceed(joinPoint)
+        } catch (e: TransactionTimedOutException) {
+            throw e
+        } finally {
+            try {
+                rLock.unlock()
+            } catch (e: IllegalMonitorStateException) {
+//                log.error(e.toString() + baseKey + dynamicKey)
+                throw e
+            }
+        }
+    }
+
+    fun getDynamicKeyFromMethodArg(
+        methodParameterNames: Array<String>,
+        args: Array<Any>,
+        paramName: String,
+    ): String {
+        for (i in methodParameterNames.indices) {
+            if ((methodParameterNames[i] == paramName)) {
+                return args[i].toString()
+            }
+        }
+        throw Exception("에러정책 이후 변할 예정")
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
@@ -18,7 +18,7 @@ class RedissonLockAop(
 ) {
 
     @Around("@annotation(com.depromeet.whatnow.common.aop.lock.RedissonLock)")
-    fun lock(joinPoint: ProceedingJoinPoint): Any {
+    fun lock(joinPoint: ProceedingJoinPoint): Any? {
         val signature = joinPoint.signature as MethodSignature
         val method = signature.method
         val redissonLock = method.getAnnotation(RedissonLock::class.java)

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/config/RedissonAopTests.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/config/RedissonAopTests.kt
@@ -1,0 +1,4 @@
+package com.depromeet.whatnow.config
+
+class RedissonAopTests {
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/config/RedissonAopTests.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/config/RedissonAopTests.kt
@@ -1,4 +1,41 @@
 package com.depromeet.whatnow.config
 
+import com.depromeet.whatnow.common.aop.lock.RedissonLock
+import com.depromeet.whatnow.helper.CunCurrencyExecutorHelper
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicLong
+
+@DomainIntegrateSpringBootTest
 class RedissonAopTests {
+
+    @Autowired lateinit var orderService: OrderService
+
+    @Service
+    class OrderService(
+        var stock: Int = 100,
+    ) {
+
+        @RedissonLock("id", "stockLock")
+        fun decreaseStock(id: Int) {
+            stock -= 1
+        }
+    }
+
+    @Test
+    fun `분산락 적용시 동시요청에 올바르게 재고가 감소해야한다`() {
+        // given
+        // when
+        val successCount = AtomicLong()
+        CunCurrencyExecutorHelper.execute(
+            { orderService.decreaseStock(1) },
+            successCount,
+        )
+        // then
+
+        val remain = 100 - successCount.toInt()
+        assertThat(orderService.stock).isEqualTo(remain)
+    }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/CunCurrencyExecutorHelper.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/CunCurrencyExecutorHelper.kt
@@ -4,10 +4,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
-class CunCurrencyExecutorService {
+class CunCurrencyExecutorHelper {
     companion object {
-        private const val numberOfThreads = 10
-        private const val numberOfThreadPool = 5
+        private const val numberOfThreads = 50
+        private const val numberOfThreadPool = 10
 
         fun execute(operation: () -> Any?, successCount: AtomicLong) {
             val executorService = Executors.newFixedThreadPool(numberOfThreadPool)
@@ -15,12 +15,13 @@ class CunCurrencyExecutorService {
             for (i in 1..numberOfThreads) {
                 executorService.submit {
                     try {
-                        operation();
+                        operation()
                         // 오류없이 성공을 하면 성공횟수를 증가시킵니다.
-                        successCount.getAndIncrement();
+                        successCount.getAndIncrement()
                     } catch (e: Throwable) {
                         // 에러뜨면 여기서 확인해보셔요!
-//                    log.info(e.javaClass.name)
+                        println(e.javaClass.name)
+                        println(e.stackTrace)
                     } finally {
                         latch.countDown()
                     }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/CunCurrencyExecutorService.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/CunCurrencyExecutorService.kt
@@ -1,0 +1,32 @@
+package com.depromeet.whatnow.helper
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicLong
+
+class CunCurrencyExecutorService {
+    companion object {
+        private const val numberOfThreads = 10
+        private const val numberOfThreadPool = 5
+
+        fun execute(operation: () -> Any?, successCount: AtomicLong) {
+            val executorService = Executors.newFixedThreadPool(numberOfThreadPool)
+            val latch = CountDownLatch(numberOfThreads)
+            for (i in 1..numberOfThreads) {
+                executorService.submit {
+                    try {
+                        operation();
+                        // 오류없이 성공을 하면 성공횟수를 증가시킵니다.
+                        successCount.getAndIncrement();
+                    } catch (e: Throwable) {
+                        // 에러뜨면 여기서 확인해보셔요!
+//                    log.info(e.javaClass.name)
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+            latch.await()
+        }
+    }
+}

--- a/Whatnow-Infrastructure/build.gradle.kts
+++ b/Whatnow-Infrastructure/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies{
     api ("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
     api ("io.github.openfeign:feign-jackson:12.1")
     api ("org.springframework.boot:spring-boot-starter-data-redis")
+    api ("org.redisson:redisson:3.19.0")
+
 
     testImplementation ("org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.1.5")
     testImplementation ("org.springframework.cloud:spring-cloud-contract-wiremock:3.1.5")

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedissonConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedissonConfig.kt
@@ -1,0 +1,26 @@
+package com.depromeet.whatnow.config.redis
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(
+    @Value("\${spring.redis.host}")
+    private val redisHost: String,
+
+    @Value("\${spring.redis.port}")
+    private val redisPort: Int,
+) {
+    private val REDISSON_HOST_PREFIX = "redis://"
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        config.useSingleServer().address = "$REDISSON_HOST_PREFIX$redisHost:$redisPort"
+        return Redisson.create(config)
+    }
+}


### PR DESCRIPTION
## 개요
- close #16 

## 작업사항
- 분산락 AOP만들었습니다
- RedissonLock 기준으로 동작합니다.
- 동시요청 쉽게해주는 CunCurrencyExecutorHelper 만들었습니다.
```kotlin
@Service
    class OrderService(
        var stock: Int = 100, // 여러 쓰레드들이 동시접근가능한 필드
    ) {

        @RedissonLock("id", "stockLock")
        fun decreaseStock(id: Int) {
            stock -= 1
        }
    }

```
굳이 디비 안갔다와도 필드에서 동시성 이슈 만들 수 있으니 
이너클래스로 테스트용 클래스만들고 
동시성 테스트 수행했습니다.

## 변경로직
- 내용을 적어주세요.