### PR TITLE
fix : redis cache 관련 테스트 수정

### DIFF
--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/event/EventPublisherAspect.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/event/EventPublisherAspect.kt
@@ -17,7 +17,7 @@ class EventPublisherAspect : ApplicationEventPublisherAware {
     private val appliedLocal: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
 
     @Around("@annotation(org.springframework.transaction.annotation.Transactional)")
-    fun handleEvent(joinPoint: ProceedingJoinPoint): Any {
+    fun handleEvent(joinPoint: ProceedingJoinPoint): Any? {
         val appliedValue = appliedLocal.get()
         // nested를 쓰는이유
         // 트랜잭션 안에 트랜잭션이 또있는 경우대비

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
@@ -1,5 +1,8 @@
 package com.depromeet.whatnow.config.redis
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -16,6 +19,14 @@ import java.time.Duration
 @Configuration
 class RedisCacheConfig {
 
+    val objectMapper: ObjectMapper = jacksonObjectMapper()
+        .activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Any::class.java)
+                .build(),
+            ObjectMapper.DefaultTyping.EVERYTHING,
+        )
+
     @Bean
     fun oidcCacheManager(cf: RedisConnectionFactory): CacheManager {
         val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
@@ -27,7 +38,7 @@ class RedisCacheConfig {
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair
                     .fromSerializer(
-                        GenericJackson2JsonRedisSerializer(),
+                        GenericJackson2JsonRedisSerializer(objectMapper),
                     ),
             )
             .entryTtl(Duration.ofDays(7L))

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/redis/RedisCacheConfig.kt
@@ -25,9 +25,10 @@ class RedisCacheConfig {
                 ),
             )
             .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    GenericJackson2JsonRedisSerializer(),
-                ),
+                RedisSerializationContext.SerializationPair
+                    .fromSerializer(
+                        GenericJackson2JsonRedisSerializer(),
+                    ),
             )
             .entryTtl(Duration.ofDays(7L))
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -45,23 +45,23 @@ class KakaoOauthClientTest {
         assertEquals(response.refreshToken, "refreshToken")
     }
 
-//    @Test
-//    fun `카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
-//        val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
-//        WireMock.stubFor(
-//            WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
-//                .willReturn(
-//                    WireMock.aResponse()
-//                        .withStatus(HttpStatus.OK.value())
-//                        .withHeader(
-//                            "Content-Type",
-//                            MediaType.APPLICATION_JSON_VALUE,
-//                        )
-//                        .withBody(Files.readAllBytes(file)),
-//                ),
-//        )
-//        var response = kakaoOauthClient.kakaoOIDCOpenKeys()
-//        assertEquals(response.keys[0].kid, "kid1")
-//        assertEquals(response.keys[1].kid, "kid2")
-//    }
+    @Test
+    fun `카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
+        val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(
+                            "Content-Type",
+                            MediaType.APPLICATION_JSON_VALUE,
+                        )
+                        .withBody(Files.readAllBytes(file)),
+                ),
+        )
+        var response = kakaoOauthClient.kakaoOIDCOpenKeys()
+        assertEquals(response.keys[0].kid, "kid1")
+        assertEquals(response.keys[1].kid, "kid2")
+    }
 }

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoOauthClientTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -45,23 +46,23 @@ class KakaoOauthClientTest {
         assertEquals(response.refreshToken, "refreshToken")
     }
 
-    @Test
-    fun `카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
-        val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
-        WireMock.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
-                .willReturn(
-                    WireMock.aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(
-                            "Content-Type",
-                            MediaType.APPLICATION_JSON_VALUE,
-                        )
-                        .withBody(Files.readAllBytes(file)),
-                ),
-        )
-        var response = kakaoOauthClient.kakaoOIDCOpenKeys()
-        assertEquals(response.keys[0].kid, "kid1")
-        assertEquals(response.keys[1].kid, "kid2")
-    }
+//    @Test
+//    fun `카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다`() {
+//        val file = ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json").toPath()
+//        WireMock.stubFor(
+//            WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
+//                .willReturn(
+//                    WireMock.aResponse()
+//                        .withStatus(HttpStatus.OK.value())
+//                        .withHeader(
+//                            "Content-Type",
+//                            MediaType.APPLICATION_JSON_VALUE,
+//                        )
+//                        .withBody(Files.readAllBytes(file)),
+//                ),
+//        )
+//        var response = kakaoOauthClient.kakaoOIDCOpenKeys()
+//        assertEquals(response.keys[0].kid, "kid1")
+//        assertEquals(response.keys[1].kid, "kid2")
+//    }
 }


### PR DESCRIPTION
## 개요
- close #22 

## 작업사항
- AOP 만들 때 join...point 리턴 값이 Any? 여야하네요....
- 추가적으로 cacheable 되어있는 어노테이션...
- 테스트 반복해서 돌리면 깨지더라고요
- 처음은 잘되는데 일단 주석처리하고 나중에 함 다시 보겠습니다.
--->>
레디스 캐시관련해서 고쳤슴다
관련 레퍼런스

원래 코틀린이 잘 안됐었나 봐유

- https://github.com/FasterXML/jackson-databind/issues/2349
- https://velog.io/@haeyon098/Redis-%EC%BA%90%EC%8B%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
- https://stackoverflow.com/questions/52265326/how-can-i-easily-cache-kotlin-objects-in-redis-using-json-via-jackson
- https://github.com/spring-projects/spring-data-redis/issues/1566




## 변경로직
- 내용을 적어주세요.