### PR TITLE
[DPMBE-36] feat : 유저 탈퇴 기능 추가

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
@@ -11,9 +11,12 @@ import com.depromeet.whatnow.api.auth.usecase.LogoutUseCase
 import com.depromeet.whatnow.api.auth.usecase.OauthUserInfoUseCase
 import com.depromeet.whatnow.api.auth.usecase.RefreshUseCase
 import com.depromeet.whatnow.api.auth.usecase.RegisterUserUseCase
+import com.depromeet.whatnow.api.auth.usecase.WithDrawUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -31,6 +34,7 @@ class AuthController(
     val loginUseCase: LoginUseCase,
     val refreshUseCase: RefreshUseCase,
     val logoutUseCase: LogoutUseCase,
+    val withDrawUseCase: WithDrawUseCase,
 ) {
 
     @Operation(summary = "개발용 회원가입입니다 ( 백엔드용 )", deprecated = true)
@@ -101,5 +105,12 @@ class AuthController(
     @PostMapping("/logout")
     fun logoutUser() {
         logoutUseCase.execute()
+    }
+
+    @Operation(summary = "회원탈퇴를 합니다.")
+    @SecurityRequirement(name = "access-token")
+    @DeleteMapping("/me")
+    fun withDrawUser() {
+        withDrawUseCase.execute()
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
@@ -15,7 +15,6 @@ import com.depromeet.whatnow.api.auth.usecase.WithDrawUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/response/OauthUserInfoResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/response/OauthUserInfoResponse.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.api.auth.dto.response
 import com.depromeet.whatnow.api.auth.helper.OauthUserInfoDto
 
 data class OauthUserInfoResponse(
-    val email: String,
+    val email: String?,
     val profileImage: String,
     val isDefaultImage: Boolean,
     val username: String,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
@@ -5,6 +5,7 @@ import com.depromeet.whatnow.api.KakaoOauthClient
 import com.depromeet.whatnow.api.dto.KakaoInformationResponse
 import com.depromeet.whatnow.api.dto.KakaoTokenResponse
 import com.depromeet.whatnow.api.dto.OIDCPublicKeysResponse
+import com.depromeet.whatnow.api.dto.UnlinkKaKaoTarget
 import com.depromeet.whatnow.config.OauthProperties
 import com.depromeet.whatnow.config.jwt.OIDCDecodePayload
 import com.depromeet.whatnow.config.static.BEARER
@@ -58,10 +59,10 @@ class KakaoOauthHelper(
         return OauthInfo(oidcDecodePayload.sub, OauthProvider.KAKAO)
     }
 
-    fun unlink(oid: String?) {
-        val kakaoAdminKey: String = oauthProperties.kakao.()
-        val unlinkKaKaoTarget: UnlinkKaKaoTarget = UnlinkKaKaoTarget.from(oid)
-        val header: String = "KakaoAK $kakaoAdminKey"
+    fun unlink(oid: String) {
+        val kakaoAdminKey: String = oauthProperties.kakao.adminKey
+        val unlinkKaKaoTarget: UnlinkKaKaoTarget = UnlinkKaKaoTarget(oid)
+        val header = "KakaoAK $kakaoAdminKey"
         kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
@@ -61,7 +61,7 @@ class KakaoOauthHelper(
 
     fun unlink(oid: String) {
         val kakaoAdminKey: String = oauthProperties.kakao.adminKey
-        val unlinkKaKaoTarget: UnlinkKaKaoTarget = UnlinkKaKaoTarget(oid)
+        val unlinkKaKaoTarget = UnlinkKaKaoTarget(oid)
         val header = "KakaoAK $kakaoAdminKey"
         kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget)
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
@@ -57,11 +57,11 @@ class KakaoOauthHelper(
         val oidcDecodePayload: OIDCDecodePayload = getOIDCDecodePayload(idToken)
         return OauthInfo(oidcDecodePayload.sub, OauthProvider.KAKAO)
     }
-    // 회원탈퇴용 나중에 만들예정
-//    fun unlink(oid: String?) {
-//        val kakaoAdminKey: String = oauthProperties.getKakaoAdminKey()
-//        val unlinkKaKaoTarget: UnlinkKaKaoTarget = UnlinkKaKaoTarget.from(oid)
-//        val header: String = "KakaoAK $kakaoAdminKey"
-//        kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget)
-//    }
+
+    fun unlink(oid: String?) {
+        val kakaoAdminKey: String = oauthProperties.kakao.()
+        val unlinkKaKaoTarget: UnlinkKaKaoTarget = UnlinkKaKaoTarget.from(oid)
+        val header: String = "KakaoAK $kakaoAdminKey"
+        kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget)
+    }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/OauthUserInfoDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/OauthUserInfoDto.kt
@@ -8,7 +8,7 @@ data class OauthUserInfoDto(
     val profileImage: String,
     val isDefaultImage: Boolean,
     val username: String,
-    val email: String,
+    val email: String?,
     val oauthProvider: OauthProvider,
 ) {
     fun toOauthInfo(): OauthInfo {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/WithDrawUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/WithDrawUseCase.kt
@@ -4,7 +4,6 @@ import com.depromeet.whatnow.api.auth.helper.KakaoOauthHelper
 import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.user.adapter.RefreshTokenAdapter
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
-import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.service.UserDomainService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,10 +13,10 @@ class WithDrawUseCase(
     val refreshTokenAdapter: RefreshTokenAdapter,
     val userAdapter: UserAdapter,
     val userDomainService: UserDomainService,
-    val kakaoOauthHelper: KakaoOauthHelper
+    val kakaoOauthHelper: KakaoOauthHelper,
 ) {
 
-   @Transactional
+    @Transactional
     fun execute() {
         val currentUserId: Long = SecurityUtils.currentUserId
         refreshTokenAdapter.deleteByUserId(currentUserId)
@@ -25,5 +24,5 @@ class WithDrawUseCase(
         val oid = user.oauthInfo.oauthId
         userDomainService.withDrawUser(currentUserId)
         kakaoOauthHelper.unlink(oid)
-   }
+    }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/WithDrawUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/WithDrawUseCase.kt
@@ -1,0 +1,29 @@
+package com.depromeet.whatnow.api.auth.usecase
+
+import com.depromeet.whatnow.api.auth.helper.KakaoOauthHelper
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.user.adapter.RefreshTokenAdapter
+import com.depromeet.whatnow.domains.user.adapter.UserAdapter
+import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.service.UserDomainService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class WithDrawUseCase(
+    val refreshTokenAdapter: RefreshTokenAdapter,
+    val userAdapter: UserAdapter,
+    val userDomainService: UserDomainService,
+    val kakaoOauthHelper: KakaoOauthHelper
+) {
+
+   @Transactional
+    fun execute() {
+        val currentUserId: Long = SecurityUtils.currentUserId
+        refreshTokenAdapter.deleteByUserId(currentUserId)
+        val user = userAdapter.queryUser(currentUserId)
+        val oid = user.oauthInfo.oauthId
+        userDomainService.withDrawUser(currentUserId)
+        kakaoOauthHelper.unlink(oid)
+   }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
@@ -10,7 +10,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import org.springframework.web.util.WebUtils
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -34,12 +33,6 @@ class JwtTokenFilter(
     }
 
     private fun resolveToken(request: HttpServletRequest): String? {
-        // 쿠키방식 지원
-        val accessTokenCookie = WebUtils.getCookie(request, "accessToken")
-        if (accessTokenCookie != null) {
-            return accessTokenCookie.value
-        }
-        // 기존 jwt 방식 지원
         val rawHeader = request.getHeader(AUTH_HEADER)
         return if (rawHeader != null && rawHeader.length > BEARER.length && rawHeader.startsWith(
                 BEARER,

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
@@ -24,6 +24,7 @@ const val KID = "kid"
 const val PROD = "prod"
 const val DEV = "dev"
 const val LOCAL = "local"
+const val WITHDRAW_PREFIX = "withdraw"
 
 val SWAGGER_PATTERNS = arrayOf(
     "/swagger-resources/**",

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/OauthInfo.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/OauthInfo.kt
@@ -1,5 +1,7 @@
 package com.depromeet.whatnow.domains.user.domain
 
+import com.depromeet.whatnow.consts.WITHDRAW_PREFIX
+import java.time.LocalDateTime
 import javax.persistence.Embeddable
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -10,4 +12,10 @@ class OauthInfo(
 
     @Enumerated(EnumType.STRING)
     var oauthProvider: OauthProvider,
-)
+) {
+
+    fun withDrawOauthInfo(): OauthInfo {
+        val withDrawOid = WITHDRAW_PREFIX + LocalDateTime.now().toString() + ":" + oauthId
+        return OauthInfo(withDrawOid, oauthProvider)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -54,4 +54,15 @@ class User(
         }
         lastLoginAt = LocalDateTime.now()
     }
+
+    fun withDraw() {
+        if (status == UserStatus.DELETED) {
+//            throw AlreadyDeletedUserException.EXCEPTION
+        }
+        status = UserStatus.DELETED
+        nickname = "탈퇴유저"
+        profileImg = ""
+        fcmToken = ""
+        oauthInfo = oauthInfo.withDrawOauthInfo()
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -46,4 +46,8 @@ class UserDomainService(
         user.login()
         return user
     }
+
+    @Transactional
+    fun withDrawUser(currentUserId: Long) {
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -3,6 +3,7 @@ package com.depromeet.whatnow.domains.user.service
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -49,5 +50,7 @@ class UserDomainService(
 
     @Transactional
     fun withDrawUser(currentUserId: Long) {
+        val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw Error("유저없으면 안됨 나중에 바꿀거임 이에러") }
+        user.withDraw()
     }
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
@@ -16,6 +16,7 @@ interface KakaoInfoClient {
 
     @PostMapping(path = ["/v1/user/unlink"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
     fun unlinkUser(
-            @RequestHeader("Authorization") adminKey: String, unlinkKaKaoTarget: UnlinkKaKaoTarget
+        @RequestHeader("Authorization") adminKey: String,
+        unlinkKaKaoTarget: UnlinkKaKaoTarget,
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
@@ -1,8 +1,11 @@
 package com.depromeet.whatnow.api
 
 import com.depromeet.whatnow.api.dto.KakaoInformationResponse
+import com.depromeet.whatnow.api.dto.UnlinkKaKaoTarget
 import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 
 // TODO : 에러 정책 확립되면 feign 에러 config 하기 , configuration = [KakaoInfoConfig::class]
@@ -11,8 +14,8 @@ interface KakaoInfoClient {
     @GetMapping("/v2/user/me")
     fun kakaoUserInfo(@RequestHeader("Authorization") accessToken: String): KakaoInformationResponse
 
-    // TODO : 회원탈퇴
-//    @PostMapping(path = ["/v1/user/unlink"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
-//    fun unlinkUser(
-//            @RequestHeader("Authorization") adminKey: String, unlinkKaKaoTarget: UnlinkKaKaoTarget)
+    @PostMapping(path = ["/v1/user/unlink"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    fun unlinkUser(
+            @RequestHeader("Authorization") adminKey: String, unlinkKaKaoTarget: UnlinkKaKaoTarget
+    )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoInfoClient.kt
@@ -1,15 +1,17 @@
 package com.depromeet.whatnow.api
 
+import com.depromeet.whatnow.api.config.KakaoInfoConfig
 import com.depromeet.whatnow.api.dto.KakaoInformationResponse
 import com.depromeet.whatnow.api.dto.UnlinkKaKaoTarget
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 
 // TODO : 에러 정책 확립되면 feign 에러 config 하기 , configuration = [KakaoInfoConfig::class]
-@FeignClient(name = "KakaoInfoClient", url = "\${feign.kakao.info}")
+@FeignClient(name = "KakaoInfoClient", url = "\${feign.kakao.info}", configuration = [KakaoInfoConfig::class])
 interface KakaoInfoClient {
     @GetMapping("/v2/user/me")
     fun kakaoUserInfo(@RequestHeader("Authorization") accessToken: String): KakaoInformationResponse
@@ -17,6 +19,6 @@ interface KakaoInfoClient {
     @PostMapping(path = ["/v1/user/unlink"], consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
     fun unlinkUser(
         @RequestHeader("Authorization") adminKey: String,
-        unlinkKaKaoTarget: UnlinkKaKaoTarget,
+        @RequestBody unlinkKaKaoTarget: UnlinkKaKaoTarget,
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoConfig.kt
@@ -1,0 +1,22 @@
+package com.depromeet.whatnow.api.config
+
+import feign.codec.Encoder
+import feign.form.spring.SpringFormEncoder
+import org.springframework.beans.factory.ObjectFactory
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters
+import org.springframework.cloud.openfeign.support.SpringEncoder
+import org.springframework.context.annotation.Bean
+
+// @Import(KakaoInfoErrorDecoder::class)
+class KakaoInfoConfig {
+//    @Bean
+//    @ConditionalOnMissingBean(value = [ErrorDecoder::class])
+//    fun commonFeignErrorDecoder(): KakaoInfoErrorDecoder {
+//        return KakaoInfoErrorDecoder()
+//    }
+
+    @Bean
+    fun encoder(converters: ObjectFactory<HttpMessageConverters>): Encoder {
+        return SpringFormEncoder(SpringEncoder(converters))
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
@@ -18,7 +18,7 @@ data class KakaoInformationResponse(
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class KakaoAccount(
         val profile: Profile,
-        val email: String,
+        val email: String?,
     ) {
 
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
@@ -4,5 +4,5 @@ import feign.form.FormProperty
 
 data class UnlinkKaKaoTarget(@FormProperty("target_id") val aud: String) {
     @FormProperty("target_id_type")
-     val targetIdType = "user_id"
+    val targetIdType = "user_id"
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
@@ -1,0 +1,8 @@
+package com.depromeet.whatnow.api.dto
+
+import feign.form.FormProperty
+
+data class UnlinkKaKaoTarget(@FormProperty("target_id") val aud: String) {
+    @FormProperty("target_id_type")
+     val targetIdType = "user_id"
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/UnlinkKaKaoTarget.kt
@@ -2,7 +2,9 @@ package com.depromeet.whatnow.api.dto
 
 import feign.form.FormProperty
 
-data class UnlinkKaKaoTarget(@FormProperty("target_id") val aud: String) {
+// https://github.com/OpenFeign/feign-form/issues/79
+// val private final이라서 안되는 이슈가 있었음 var 로 바꿔야함.
+data class UnlinkKaKaoTarget(@FormProperty("target_id") var aud: String) {
     @FormProperty("target_id_type")
-    val targetIdType = "user_id"
+    var targetIdType = "user_id"
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
@@ -14,6 +14,6 @@ data class OauthProperties(
         val clientSecret: String,
         val redirectUrl: String,
         val appId: String,
-        val adminKey : String,
+        val adminKey: String,
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/OauthProperties.kt
@@ -14,5 +14,6 @@ data class OauthProperties(
         val clientSecret: String,
         val redirectUrl: String,
         val appId: String,
+        val adminKey : String,
     )
 }

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -20,7 +20,7 @@ oauth:
     client-secret: ${KAKAO_SECRET}
     redirect-url: ${KAKAO_REDIRECT}
     app-id: ${KAKAO_APP_ID:default}
-    admin-key: ${KAKAO_ADMIN_KEY}
+    admin-key: ${KAKAO_ADMIN_KEY:}
 feign:
   kakao:
     info : https://kapi.kakao.com


### PR DESCRIPTION
## 개요
- close #27 

## 작업사항
- 호ㅣ원 탈퇴기능 만들었습니다.
- 유저 이메일 정말안주더라고요? 그래서.. 옵셔널 처리했습니다.
- 이야기해보고 아예빼면 좋을듯

- 회원탈퇴할때 카카오한테 unlink 날려야하고 폼데이터 형식이라 페인 config 설정좀 했습니당.
- 탈퇴한유저정보를 어떻게 변형시킬지는 한번 다시 이야기해보면 좋을것같아요.
- 일단지금은 닉네임 탈퇴유저로 바꾸고 다지우는 느낌으로 해놨습니당

## 변경로직
- 내용을 적어주세요.