### PR TITLE
[DPMBE-37] refactor : 에러 정책 수립이후 기본에러 비즈니스 에러로 전환

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.example.controller
 
 import com.depromeet.whatnow.annotation.ApiErrorCodeExample
+import com.depromeet.whatnow.api.config.KakaoKauthErrorCode
 import com.depromeet.whatnow.domains.user.exception.UserErrorCode
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import io.swagger.v3.oas.annotations.Operation
@@ -23,4 +24,9 @@ class ExampleController() {
     @Operation(summary = "유저 도메인 관련 에러 코드 나열")
     @ApiErrorCodeExample(UserErrorCode::class)
     fun userErrorCode() {}
+
+    @GetMapping("/kakao")
+    @Operation(summary = "카카오 auth 관련 에러코드 나열")
+    @ApiErrorCodeExample(KakaoKauthErrorCode::class)
+    fun kakaoErrorCode() {}
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
@@ -1,0 +1,26 @@
+package com.depromeet.whatnow.api.example.controller
+
+import com.depromeet.whatnow.annotation.ApiErrorCodeExample
+import com.depromeet.whatnow.domains.user.exception.UserErrorCode
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/example")
+@Tag(name = "X. [예시]")
+class ExampleController() {
+
+    @GetMapping("/global")
+    @Operation(summary = "글로벌 ( 인증 , aop, 서버 내부 오류등)  관련 에러 코드 나열")
+    @ApiErrorCodeExample(GlobalErrorCode::class)
+    fun globalErrorcode() {}
+
+    @GetMapping("/user")
+    @Operation(summary = "유저 도메인 관련 에러 코드 나열")
+    @ApiErrorCodeExample(UserErrorCode::class)
+    fun userErrorCode() {}
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtOIDCHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtOIDCHelper.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.config.jwt
 
 import com.depromeet.whatnow.config.consts.KID
+import com.depromeet.whatnow.exception.custom.InvalidTokenException
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Header
 import io.jsonwebtoken.Jws
@@ -32,7 +33,7 @@ class JwtOIDCHelper {
 
     private fun getUnsignedToken(token: String): String {
         val splitToken = token.split("\\.".toRegex())
-        if (splitToken.size != 3) throw Exception("에러정책이후 바꿀예정")
+        if (splitToken.size != 3) throw InvalidTokenException.EXCEPTION
         return splitToken[0] + "." + splitToken[1] + "."
     }
 

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtTokenHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtTokenHelper.kt
@@ -6,6 +6,9 @@ import com.depromeet.whatnow.config.static.REFRESH_TOKEN
 import com.depromeet.whatnow.config.static.TOKEN_ISSUER
 import com.depromeet.whatnow.config.static.TOKEN_ROLE
 import com.depromeet.whatnow.config.static.TOKEN_TYPE
+import com.depromeet.whatnow.exception.custom.ExpiredTokenException
+import com.depromeet.whatnow.exception.custom.InvalidTokenException
+import com.depromeet.whatnow.exception.custom.RefreshTokenExpiredException
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
@@ -91,7 +94,7 @@ class JwtTokenHelper(
             val claims: Claims = getJws(token).body
             return AccessTokenInfo(claims.subject.toLong(), claims[TOKEN_ROLE] as String)
         }
-        throw Exception("에러정책이후 바꿀예정")
+        throw InvalidTokenException.EXCEPTION
     }
 
     fun parseRefreshToken(token: String): Long {
@@ -100,9 +103,9 @@ class JwtTokenHelper(
                 val claims: Claims = getJws(token).body
                 return claims.subject.toLong()
             }
-        } catch (e: Exception) {
-            throw Exception("에러정책이후 바꿀예정")
+        } catch (e: ExpiredTokenException) {
+            throw RefreshTokenExpiredException.EXCEPTION
         }
-        throw Exception("에러정책이후 바꿀예정")
+        throw InvalidTokenException.EXCEPTION
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/TokenParseExecuters.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/TokenParseExecuters.kt
@@ -1,5 +1,7 @@
 package com.depromeet.whatnow.config.jwt
 
+import com.depromeet.whatnow.exception.custom.ExpiredTokenException
+import com.depromeet.whatnow.exception.custom.InvalidTokenException
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Header
@@ -11,31 +13,29 @@ import io.jsonwebtoken.UnsupportedJwtException
 fun JwtParseExecuter(operation: () -> Jwt<Header<*>, Claims>): Jwt<Header<*>, Claims> {
     return try {
         operation()
-    } catch (e: io.jsonwebtoken.security.SecurityException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: MalformedJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: ExpiredJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: UnsupportedJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: IllegalArgumentException) {
-        throw Exception("에러정책이후 바꿀예정")
+    } catch (ex: Exception) {
+        when (ex) {
+            is io.jsonwebtoken.security.SecurityException,
+            is MalformedJwtException,
+            is UnsupportedJwtException,
+            is IllegalArgumentException -> throw InvalidTokenException.EXCEPTION
+            is ExpiredJwtException -> throw ExpiredTokenException.EXCEPTION
+            else -> throw ex
+        }
     }
 }
 
 fun JwsParseExecuter(operation: () -> Jws<Claims>): Jws<Claims> {
     return try {
         operation()
-    } catch (e: io.jsonwebtoken.security.SecurityException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: MalformedJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: ExpiredJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: UnsupportedJwtException) {
-        throw Exception("에러정책이후 바꿀예정")
-    } catch (e: IllegalArgumentException) {
-        throw Exception("에러정책이후 바꿀예정")
+    } catch (ex: Exception) {
+        when (ex) {
+            is io.jsonwebtoken.security.SecurityException,
+            is MalformedJwtException,
+            is UnsupportedJwtException,
+            is IllegalArgumentException -> throw InvalidTokenException.EXCEPTION
+            is ExpiredJwtException -> throw ExpiredTokenException.EXCEPTION
+            else -> throw ex
+        }
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/TokenParseExecuters.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/TokenParseExecuters.kt
@@ -18,7 +18,8 @@ fun JwtParseExecuter(operation: () -> Jwt<Header<*>, Claims>): Jwt<Header<*>, Cl
             is io.jsonwebtoken.security.SecurityException,
             is MalformedJwtException,
             is UnsupportedJwtException,
-            is IllegalArgumentException -> throw InvalidTokenException.EXCEPTION
+            is IllegalArgumentException,
+            -> throw InvalidTokenException.EXCEPTION
             is ExpiredJwtException -> throw ExpiredTokenException.EXCEPTION
             else -> throw ex
         }
@@ -33,7 +34,8 @@ fun JwsParseExecuter(operation: () -> Jws<Claims>): Jws<Claims> {
             is io.jsonwebtoken.security.SecurityException,
             is MalformedJwtException,
             is UnsupportedJwtException,
-            is IllegalArgumentException -> throw InvalidTokenException.EXCEPTION
+            is IllegalArgumentException,
+            -> throw InvalidTokenException.EXCEPTION
             is ExpiredJwtException -> throw ExpiredTokenException.EXCEPTION
             else -> throw ex
         }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtExceptionFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtExceptionFilter.kt
@@ -36,7 +36,6 @@ class JwtExceptionFilter(
         return ErrorResponse.of(errorCode.errorReason, path)
     }
 
-    @Throws(IOException::class)
     private fun responseToClient(response: HttpServletResponse, errorResponse: ErrorResponse) {
         response.characterEncoding = "UTF-8"
         response.contentType = MediaType.APPLICATION_JSON_VALUE

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtExceptionFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtExceptionFilter.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import java.io.IOException
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
@@ -34,8 +34,11 @@ class JwtTokenFilter(
 
     private fun resolveToken(request: HttpServletRequest): String? {
         val rawHeader = request.getHeader(AUTH_HEADER) ?: return null
-        return if (rawHeader.length > BEARER.length && rawHeader.startsWith(BEARER))
-            rawHeader.substring(BEARER.length) else null
+        return if (rawHeader.length > BEARER.length && rawHeader.startsWith(BEARER)) {
+            rawHeader.substring(BEARER.length)
+        } else {
+            null
+        }
     }
 
     fun getAuthentication(token: String): Authentication {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/JwtTokenFilter.kt
@@ -25,7 +25,7 @@ class JwtTokenFilter(
         filterChain: FilterChain,
     ) {
         val token = resolveToken(request)
-        if (token != null) {
+        token?. run {
             val authentication = getAuthentication(token)
             SecurityContextHolder.getContext().authentication = authentication
         }
@@ -33,15 +33,9 @@ class JwtTokenFilter(
     }
 
     private fun resolveToken(request: HttpServletRequest): String? {
-        val rawHeader = request.getHeader(AUTH_HEADER)
-        return if (rawHeader != null && rawHeader.length > BEARER.length && rawHeader.startsWith(
-                BEARER,
-            )
-        ) {
-            rawHeader.substring(BEARER.length)
-        } else {
-            null
-        }
+        val rawHeader = request.getHeader(AUTH_HEADER) ?: return null
+        return if (rawHeader.length > BEARER.length && rawHeader.startsWith(BEARER))
+            rawHeader.substring(BEARER.length) else null
     }
 
     fun getAuthentication(token: String): Authentication {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/SecurityConfig.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/SecurityConfig.kt
@@ -44,7 +44,6 @@ class SecurityConfig(
     }
 
     @Bean
-    @Throws(Exception::class)
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http.formLogin().disable().cors().and().csrf().disable()
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/SecurityUtils.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/SecurityUtils.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.config.security
 
+import com.depromeet.whatnow.exception.custom.SecurityContextNotFoundException
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.util.CollectionUtils
@@ -13,7 +14,7 @@ class SecurityUtils {
         val currentUserId: Long
             get() {
                 val authentication = SecurityContextHolder.getContext().authentication
-                    ?: throw Error("비즈니스 에러로 전환예정")
+                    ?: throw SecurityContextNotFoundException.EXCEPTION
                 return if (authentication.isAuthenticated && !CollectionUtils.containsAny(authentication.authorities, notUserAuthority)) {
                     authentication.name.toLong()
                 } else {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
@@ -109,7 +109,6 @@ class SwaggerConfig {
             // ApiErrorCodeExample 어노테이션 단 메소드 적용
             apiErrorCodeExample ?.run {
                 generateErrorCodeResponseExample(operation, apiErrorCodeExample.value)
-
             }
             operation
         }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
@@ -94,20 +94,22 @@ class SwaggerConfig {
                 handlerMethod.getMethodAnnotation(ApiErrorCodeExample::class.java)
             val tags = getTags(handlerMethod)
             // DisableSecurity 어노테이션있을시 스웨거 시큐리티 설정 삭제
-            if (methodAnnotation != null) {
+            methodAnnotation ?.run {
                 operation.security = emptyList()
             }
+
             // 태그 중복 설정시 제일 구체적인 값만 태그로 설정
-            if (!tags.isEmpty()) {
+            if (tags.isNotEmpty()) {
                 operation.tags = listOf(tags[0])
             }
             // ApiErrorExceptionsExample 어노테이션 단 메소드 적용
-            if (apiErrorExceptionsExample != null) {
+            apiErrorExceptionsExample ?.run {
                 generateExceptionResponseExample(operation, apiErrorExceptionsExample.value.java)
             }
             // ApiErrorCodeExample 어노테이션 단 메소드 적용
-            if (apiErrorCodeExample != null) {
+            apiErrorCodeExample ?.run {
                 generateErrorCodeResponseExample(operation, apiErrorCodeExample.value)
+
             }
             operation
         }
@@ -121,8 +123,8 @@ class SwaggerConfig {
         val responses = operation.responses
         val errorCodes = type.java.enumConstants as? Array<out BaseErrorCode> ?: return
         val statusWithExampleHolders: Map<Int?, List<ExampleHolder>> = errorCodes
-            .mapNotNull { baseErrorCode ->
-                baseErrorCode?.errorReason?.let { errorReason ->
+            .map { baseErrorCode ->
+                baseErrorCode.errorReason.let { errorReason ->
                     try {
                         ExampleHolder.builder()
                             .holder(
@@ -157,7 +159,7 @@ class SwaggerConfig {
         val statusWithExampleHolders: Map<Int?, List<ExampleHolder>> = type.kotlin.declaredMemberProperties
             .filter { it.findAnnotation<ExplainError>() != null }
             .filter { it.returnType.classifier == WhatnowCodeException::class }
-            .mapNotNull { field ->
+            .map { field ->
                 try {
                     val exception = field.getter.call(bean) as WhatnowCodeException
                     val annotation = field.findAnnotation<ExplainError>()!!
@@ -165,7 +167,7 @@ class SwaggerConfig {
                     val errorReason = exception.errorReason
                     ExampleHolder.builder()
                         .holder(getSwaggerExample(value, errorReason))
-                        .code(errorReason?.status)
+                        .code(errorReason.status)
                         .name(field.name)
                         .build()
                 } catch (e: IllegalAccessException) {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
@@ -31,10 +31,10 @@ enum class GlobalErrorCode(val status: Int, val code: String, val reason: String
     REFRESH_TOKEN_EXPIRED(FORBIDDEN, "AUTH_403_1", "인증시간이 만료되었습니다. 인증토큰 재발급을 요청하세요"),
 
     @ExplainError("헤더에 accessToken의 형식이 틀릴떄 발생하는 오류입니다, 토큰이 위조됐을 가능성이 있습니다.")
-    INVALID_TOKEN(UNAUTHORIZED, "AUTH_403_2", "토큰의 형식이 일치하지 않습니다. 적절한 형식으로 다시 요청하세요"),
+    INVALID_TOKEN(FORBIDDEN, "AUTH_403_2", "토큰의 형식이 일치하지 않습니다. 적절한 형식으로 다시 요청하세요"),
 
     @ExplainError("헤더에 accessToken이 없을때 발생하는 오류입니다")
-    ACCESS_TOKEN_NOT_FOUND(UNAUTHORIZED, "AUTH_403_3", "토큰이 존재하지 않습니다. 적절한 토큰을 헤더에 넣어주세요"),
+    ACCESS_TOKEN_NOT_FOUND(FORBIDDEN, "AUTH_403_3", "토큰이 존재하지 않습니다. 적절한 토큰을 헤더에 넣어주세요"),
 
     @ExplainError("없는 resource로 요청했습니다. 다른 요청으로 다시 시도해주세요")
     RESOURCE_NOT_FOUND(NOT_FOUND, "GLOBAL_404_1", "The requested resource was not found on the server."),

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
@@ -31,7 +31,7 @@ enum class GlobalErrorCode(val status: Int, val code: String, val reason: String
     REFRESH_TOKEN_EXPIRED(FORBIDDEN, "AUTH_403_1", "인증시간이 만료되었습니다. 인증토큰 재발급을 요청하세요"),
 
     @ExplainError("헤더에 accessToken의 형식이 틀릴떄 발생하는 오류입니다, 토큰이 위조됐을 가능성이 있습니다.")
-    INVALID_ACCESS_TOKEN(UNAUTHORIZED, "AUTH_403_2", "토큰의 형식이 일치하지 않습니다. 적절한 형식으로 다시 요청하세요"),
+    INVALID_TOKEN(UNAUTHORIZED, "AUTH_403_2", "토큰의 형식이 일치하지 않습니다. 적절한 형식으로 다시 요청하세요"),
 
     @ExplainError("헤더에 accessToken이 없을때 발생하는 오류입니다")
     ACCESS_TOKEN_NOT_FOUND(UNAUTHORIZED, "AUTH_403_3", "토큰이 존재하지 않습니다. 적절한 토큰을 헤더에 넣어주세요"),
@@ -77,6 +77,8 @@ enum class GlobalErrorCode(val status: Int, val code: String, val reason: String
 
     @ExplainError("다른 서버에서 발생한 알 수 없는 서버 예외입니다.")
     OTHER_SERVER_INTERNAL_SERVER_ERROR(INTERNAL_SERVER, "OTHER_SERVER_500_1", "다른 서버에서 알 수 없는 서버 오류가 발생했습니다."),
+
+    SECURITY_CONTEXT_NOT_FOUND(INTERNAL_SERVER, "GLOBAL_500_2", "security context not found"),
     ;
 
     override val errorReason: ErrorReason

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/WhatnowCodeException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/WhatnowCodeException.kt
@@ -2,7 +2,7 @@ package com.depromeet.whatnow.exception
 
 import com.depromeet.whatnow.dto.ErrorReason
 
-class WhatnowCodeException(
+open class WhatnowCodeException(
     val errorCode: BaseErrorCode,
 ) : RuntimeException() {
 

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/BadLockIdentifierException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/BadLockIdentifierException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class BadLockIdentifierException : WhatnowCodeException(
+    GlobalErrorCode.BAD_LOCK_IDENTIFIER,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = BadLockIdentifierException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/ExpiredTokenException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/ExpiredTokenException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class ExpiredTokenException : WhatnowCodeException(
+    GlobalErrorCode.TOKEN_EXPIRED,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = ExpiredTokenException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/InvalidTokenException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/InvalidTokenException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class InvalidTokenException : WhatnowCodeException(
+    GlobalErrorCode.INVALID_TOKEN,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = InvalidTokenException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotAvailableRedissonLockException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotAvailableRedissonLockException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class NotAvailableRedissonLockException : WhatnowCodeException(
+    GlobalErrorCode.NOT_AVAILABLE_REDISSON_LOCK,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = NotAvailableRedissonLockException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerBadRequestException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerBadRequestException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerBadRequestException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerBadRequestException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerExpiredTokenException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerExpiredTokenException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerExpiredTokenException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_EXPIRED_TOKEN,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerExpiredTokenException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerForbiddenException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerForbiddenException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerForbiddenException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_FORBIDDEN,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerForbiddenException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerInternalSeverErrorException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerInternalSeverErrorException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerInternalSeverErrorException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_INTERNAL_SERVER_ERROR,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerInternalSeverErrorException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerNotFoundException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerNotFoundException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerUnauthorizedException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/OtherServerUnauthorizedException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class OtherServerUnauthorizedException : WhatnowCodeException(
+    GlobalErrorCode.OTHER_SERVER_UNAUTHORIZED,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = OtherServerUnauthorizedException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/RefreshTokenExpiredException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/RefreshTokenExpiredException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class RefreshTokenExpiredException : WhatnowCodeException(
+    GlobalErrorCode.REFRESH_TOKEN_EXPIRED,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = RefreshTokenExpiredException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/SecurityContextNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/SecurityContextNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class SecurityContextNotFoundException : WhatnowCodeException(
+    GlobalErrorCode.SECURITY_CONTEXT_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = SecurityContextNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/lock/RedissonLockAop.kt
@@ -1,5 +1,7 @@
 package com.depromeet.whatnow.common.aop.lock
 
+import com.depromeet.whatnow.exception.custom.BadLockIdentifierException
+import com.depromeet.whatnow.exception.custom.NotAvailableRedissonLockException
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -30,12 +32,12 @@ class RedissonLockAop(
         try {
             val available = rLock.tryLock(redissonLock.waitTime, redissonLock.leaseTime, redissonLock.timeUnit)
             if (!available) {
-                throw Exception("에러정책 이후 변할 예정")
+                throw NotAvailableRedissonLockException.EXCEPTION
             }
 
             return redissonCallNewTransaction
                 .proceed(joinPoint)
-        } catch (e: TransactionTimedOutException) {
+        } catch (e: TransactionTimedOutException) { // WhatnowCodeException , WhatnowDynamicException
             throw e
         } finally {
             try {
@@ -57,6 +59,6 @@ class RedissonLockAop(
                 return args[i].toString()
             }
         }
-        throw Exception("에러정책 이후 변할 예정")
+        throw BadLockIdentifierException.EXCEPTION
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/RefreshTokenAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/RefreshTokenAdapter.kt
@@ -2,8 +2,8 @@ package com.depromeet.whatnow.domains.user.adapter
 
 import com.depromeet.whatnow.domains.user.domain.RefreshTokenRedisEntity
 import com.depromeet.whatnow.domains.user.repository.RefreshTokenRepository
+import com.depromeet.whatnow.exception.custom.RefreshTokenExpiredException
 import org.springframework.stereotype.Service
-import java.lang.Error
 
 @Service
 class RefreshTokenAdapter(
@@ -12,7 +12,7 @@ class RefreshTokenAdapter(
 
     fun queryRefreshToken(refreshToken: String): RefreshTokenRedisEntity {
         return refreshTokenRepository
-            .findByRefreshToken(refreshToken) ?: run { throw Error("엔티티 못찾음 에러바꾸기 나중에") }
+            .findByRefreshToken(refreshToken) ?: run { throw RefreshTokenExpiredException.EXCEPTION }
     }
 
     fun save(refreshToken: RefreshTokenRedisEntity): RefreshTokenRedisEntity {

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.user.adapter
 
 import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.exception.UserNotFoundException
 import com.depromeet.whatnow.domains.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -11,6 +12,6 @@ class UserAdapter(
 ) {
 
     fun queryUser(userId: Long): User {
-        return userRepository.findByIdOrNull(userId) ?: run { throw Error("유저없음 안됨") }
+        return userRepository.findByIdOrNull(userId) ?: run { throw UserNotFoundException.EXCEPTION }
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/AlreadyDeletedUserException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/AlreadyDeletedUserException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.user.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class AlreadyDeletedUserException : WhatnowCodeException(
+    UserErrorCode.USER_ALREADY_DELETED,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = AlreadyDeletedUserException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/AlreadySignUpUserException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/AlreadySignUpUserException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.user.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class AlreadySignUpUserException : WhatnowCodeException(
+    UserErrorCode.USER_ALREADY_SIGNUP,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = AlreadySignUpUserException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/ForbiddenUserException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/ForbiddenUserException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.user.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class ForbiddenUserException : WhatnowCodeException(
+    UserErrorCode.USER_FORBIDDEN,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = ForbiddenUserException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserErrorCode.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserErrorCode.kt
@@ -1,0 +1,36 @@
+package com.depromeet.whatnow.domains.user.exception
+
+import com.depromeet.whatnow.annotation.ExplainError
+import com.depromeet.whatnow.consts.BAD_REQUEST
+import com.depromeet.whatnow.consts.FORBIDDEN
+import com.depromeet.whatnow.consts.NOT_FOUND
+import com.depromeet.whatnow.dto.ErrorReason
+import com.depromeet.whatnow.exception.BaseErrorCode
+import java.util.*
+
+enum class UserErrorCode(val status: Int, val code: String, val reason: String) : BaseErrorCode {
+
+    @ExplainError("회원가입시에 이미 회원가입한 유저일시 발생하는 오류. 회원가입전엔 항상 register valid check 를 해주세요")
+    USER_ALREADY_SIGNUP(BAD_REQUEST, "USER_400_1", "이미 회원가입한 유저입니다."),
+
+    @ExplainError("정지 처리된 유저일 경우 밣생하는 오류")
+    USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "접근이 제한된 유저입니다."),
+
+    @ExplainError("탈퇴한 유저로 접근하려는 경우")
+    USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "이미 지워진 유저입니다."),
+
+    @ExplainError("유저 정보를 찾을 수 없는 경우")
+    USER_NOT_FOUND(NOT_FOUND, "USER_404_1", "유저 정보를 찾을 수 없습니다."),
+
+    ;
+
+    override val errorReason: ErrorReason
+        get() { return ErrorReason(status, code, reason) }
+
+    override val explainError: String
+        get() {
+            val field = this.javaClass.getField(name)
+            val annotation = field.getAnnotation(ExplainError::class.java)
+            return if (Objects.nonNull(annotation)) annotation.value else reason
+        }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserErrorCode.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserErrorCode.kt
@@ -13,7 +13,7 @@ enum class UserErrorCode(val status: Int, val code: String, val reason: String) 
     @ExplainError("회원가입시에 이미 회원가입한 유저일시 발생하는 오류. 회원가입전엔 항상 register valid check 를 해주세요")
     USER_ALREADY_SIGNUP(BAD_REQUEST, "USER_400_1", "이미 회원가입한 유저입니다."),
 
-    @ExplainError("정지 처리된 유저일 경우 밣생하는 오류")
+    @ExplainError("정지 처리된 유저일 경우 발생하는 오류")
     USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "접근이 제한된 유저입니다."),
 
     @ExplainError("탈퇴한 유저로 접근하려는 경우")

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/exception/UserNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.user.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class UserNotFoundException : WhatnowCodeException(
+    UserErrorCode.USER_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = UserNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -2,6 +2,8 @@ package com.depromeet.whatnow.domains.user.service
 
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.exception.AlreadySignUpUserException
+import com.depromeet.whatnow.domains.user.exception.UserNotFoundException
 import com.depromeet.whatnow.domains.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -37,20 +39,20 @@ class UserDomainService(
     }
 
     fun registerUser(username: String, profileImage: String, defaultImage: Boolean, oauthInfo: OauthInfo, oauthId: String): User {
-        userRepository.findByOauthInfo(oauthInfo)?. let { throw Error("이미 회원가입했으면 안됨 ( 나중에 비즈니스 에러로 교체 예정") }
+        userRepository.findByOauthInfo(oauthInfo)?. let { throw AlreadySignUpUserException.EXCEPTION }
         return userRepository.save(User(oauthInfo, username, profileImage, defaultImage))
     }
 
     @Transactional
     fun loginUser(oauthInfo: OauthInfo): User {
-        val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw Error("유저없으면 안됨 나중에 바꿀거임 이에러") }
+        val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
         user.login()
         return user
     }
 
     @Transactional
     fun withDrawUser(currentUserId: Long) {
-        val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw Error("유저없으면 안됨 나중에 바꿀거임 이에러") }
+        val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw UserNotFoundException.EXCEPTION }
         user.withDraw()
     }
 }

--- a/Whatnow-Infrastructure/build.gradle.kts
+++ b/Whatnow-Infrastructure/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies{
     api ("org.springframework.boot:spring-boot-starter-data-redis")
     api ("org.redisson:redisson:3.19.0")
 
+    implementation(project(":Whatnow-Common"))
+
+
     testImplementation ("org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.1.5")
     testImplementation ("org.springframework.cloud:spring-cloud-contract-wiremock:3.1.5")
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/KakaoOauthClient.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.api
 
+import com.depromeet.whatnow.api.config.KakaoKauthConfig
 import com.depromeet.whatnow.api.dto.KakaoTokenResponse
 import com.depromeet.whatnow.api.dto.OIDCPublicKeysResponse
 import org.springframework.cache.annotation.Cacheable
@@ -9,7 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 
 // TODO : , configuration = [KakaoKauthConfig::class] 애러정책 확립후 클라이언트 설정 들어가기
-@FeignClient(name = "KakaoAuthClient", url = "\${feign.kakao.oauth}")
+@FeignClient(name = "KakaoAuthClient", url = "\${feign.kakao.oauth}", configuration = [KakaoKauthConfig::class])
 interface KakaoOauthClient {
     @PostMapping("/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
     fun kakaoAuth(

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoConfig.kt
@@ -6,8 +6,9 @@ import org.springframework.beans.factory.ObjectFactory
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters
 import org.springframework.cloud.openfeign.support.SpringEncoder
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
 
-// @Import(KakaoInfoErrorDecoder::class)
+@Import(KakaoInfoErrorDecoder::class)
 class KakaoInfoConfig {
 //    @Bean
 //    @ConditionalOnMissingBean(value = [ErrorDecoder::class])

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoErrorDecoder.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoInfoErrorDecoder.kt
@@ -1,0 +1,23 @@
+package com.depromeet.whatnow.api.config
+
+import com.depromeet.whatnow.exception.custom.OtherServerBadRequestException
+import com.depromeet.whatnow.exception.custom.OtherServerExpiredTokenException
+import com.depromeet.whatnow.exception.custom.OtherServerForbiddenException
+import com.depromeet.whatnow.exception.custom.OtherServerUnauthorizedException
+import feign.FeignException
+import feign.Response
+import feign.codec.ErrorDecoder
+
+class KakaoInfoErrorDecoder : ErrorDecoder {
+    override fun decode(methodKey: String, response: Response): Exception {
+        if (response.status() >= 400) {
+            when (response.status()) {
+                401 -> throw OtherServerUnauthorizedException.EXCEPTION
+                403 -> throw OtherServerForbiddenException.EXCEPTION
+                419 -> throw OtherServerExpiredTokenException.EXCEPTION
+                else -> throw OtherServerBadRequestException.EXCEPTION
+            }
+        }
+        return FeignException.errorStatus(methodKey, response)
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoKauthConfig.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoKauthConfig.kt
@@ -1,0 +1,22 @@
+package com.depromeet.whatnow.api.config
+
+import feign.codec.Encoder
+import feign.codec.ErrorDecoder
+import feign.form.FormEncoder
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+
+@Import(KauthErrorDecoder::class)
+class KakaoKauthConfig {
+    @Bean
+    @ConditionalOnMissingBean(value = [ErrorDecoder::class])
+    fun commonFeignErrorDecoder(): KauthErrorDecoder {
+        return KauthErrorDecoder()
+    }
+
+    @Bean
+    fun formEncoder(): Encoder {
+        return FormEncoder()
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoKauthErrorCode.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KakaoKauthErrorCode.kt
@@ -1,0 +1,54 @@
+package com.depromeet.whatnow.api.config
+
+import com.depromeet.whatnow.annotation.ExplainError
+import com.depromeet.whatnow.consts.BAD_REQUEST
+import com.depromeet.whatnow.dto.ErrorReason
+import com.depromeet.whatnow.exception.BaseErrorCode
+import java.util.*
+
+enum class KakaoKauthErrorCode(val status: Int, val errorCode: String, val error: String, val reason: String) : BaseErrorCode {
+
+    KOE101(BAD_REQUEST, "KAKAO_KOE101", "invalid_client", "잘못된 앱 키 타입을 사용하거나 앱 키에 오타가 있을 경우"),
+    KOE009(BAD_REQUEST, "KAKAO_KOE009", "misconfigured", "등록되지 않은 플랫폼에서 액세스 토큰을 요청 하는 경우"),
+    KOE010(
+        BAD_REQUEST,
+        "KAKAO_KOE101",
+        "invalid_client",
+        "클라이언트 시크릿(Client secret) 기능을 사용하는 앱에서 토큰 요청 시 client_secret 값을 전달하지 않거나 정확하지 않은 값을 전달하는 경우",
+    ),
+    KOE303(
+        BAD_REQUEST,
+        "KAKAO_KOE303",
+        "invalid_grant",
+        "인가 코드 요청 시 사용한 redirect_uri와 액세스 토큰 요청 시 사용한 redirect_uri가 다른 경우",
+    ),
+    KOE319(BAD_REQUEST, "KAKAO_KOE319", "invalid_grant", "토큰 갱신 요청 시 리프레시 토큰을 전달하지 않는 경우"),
+    KOE320(
+        BAD_REQUEST,
+        "KAKAO_KOE320",
+        "invalid_grant",
+        "동일한 인가 코드를 두 번 이상 사용하거나, 이미 만료된 인가 코드를 사용한 경우, 혹은 인가 코드를 찾을 수 없는 경우",
+    ),
+    KOE322(
+        BAD_REQUEST,
+        "KAKAO_KOE322",
+        "invalid_grant",
+        "refresh_token을 찾을 수 없거나 이미 만료된 리프레시 토큰을 사용한 경우",
+    ),
+    KOE_INVALID_REQUEST(BAD_REQUEST, "KAKAO_KOE_INVALID_REQUEST", "invalid_request", "잘못된 요청인 경우"),
+    KOE400(BAD_REQUEST, "KAKAO_KOE400", "invalid_token", "ID 토큰 값이 전달되지 않았거나 올바른 형식이 아닌 ID 토큰인 경우"),
+    KOE401(BAD_REQUEST, "KAKAO_KOE401", "invalid_token", "ID 토큰을 발급한 인증 기관(iss)이 카카오 인증 서버"),
+    KOE402(BAD_REQUEST, "KAKAO_KOE402", "invalid_token", "서명이 올바르지 않아 유효한 ID 토큰이 아닌 경우"),
+    KOE403(BAD_REQUEST, "KAKAO_KOE403", "invalid_token", "만료된 ID 토큰인 경우"),
+    ;
+
+    override val errorReason: ErrorReason
+        get() { return ErrorReason(status, errorCode, reason) }
+
+    override val explainError: String
+        get() {
+            val field = this.javaClass.getField(name)
+            val annotation = field.getAnnotation(ExplainError::class.java)
+            return if (Objects.nonNull(annotation)) annotation.value else reason
+        }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KauthErrorDecoder.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/config/KauthErrorDecoder.kt
@@ -1,0 +1,30 @@
+package com.depromeet.whatnow.api.config
+
+import com.depromeet.whatnow.api.dto.KakaoKauthErrorResponse
+import com.depromeet.whatnow.dto.ErrorReason
+import com.depromeet.whatnow.exception.WhatNowDynamicException
+import feign.Response
+import feign.codec.ErrorDecoder
+
+class KauthErrorDecoder : ErrorDecoder {
+    override fun decode(methodKey: String, response: Response): Exception {
+        val body: KakaoKauthErrorResponse = KakaoKauthErrorResponse.from(response)
+        try {
+            val kakaoKauthErrorCode = KakaoKauthErrorCode.valueOf(body.errorCode)
+            val errorReason: ErrorReason = kakaoKauthErrorCode.errorReason
+            throw WhatNowDynamicException(
+                errorReason.status,
+                errorReason.code,
+                errorReason.reason,
+            )
+        } catch (e: IllegalArgumentException) {
+            val koeInvalidRequest = KakaoKauthErrorCode.KOE_INVALID_REQUEST
+            val errorReason: ErrorReason = koeInvalidRequest.errorReason
+            throw WhatNowDynamicException(
+                errorReason.status,
+                errorReason.code,
+                errorReason.reason,
+            )
+        }
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoKauthErrorResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoKauthErrorResponse.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.api.dto
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoKauthErrorResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoKauthErrorResponse.kt
@@ -1,0 +1,24 @@
+package com.depromeet.whatnow.api.dto
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import feign.Response
+
+@JsonNaming(SnakeCaseStrategy::class)
+data class KakaoKauthErrorResponse(
+    var error: String,
+    var errorCode: String,
+    var errorDescription: String,
+) {
+
+    companion object {
+        fun from(response: Response): KakaoKauthErrorResponse {
+            response.body().asInputStream().use { bodyIs ->
+                val mapper = jacksonObjectMapper() // for kotlin support
+                return mapper.readValue(bodyIs, KakaoKauthErrorResponse::class.java)
+            }
+        }
+    }
+}

--- a/Whatnow-Infrastructure/src/test/resources/payload/kauth-KOE320-response.json
+++ b/Whatnow-Infrastructure/src/test/resources/payload/kauth-KOE320-response.json
@@ -1,0 +1,5 @@
+{
+  "error":"invalid_grant",
+  "error_description":"authorization code not found for code=GFXukWlxWvYRGkf9Vxcm7uBrW2qt6Em1vJSrdBstbURtG7YKIo_iIzzvoxvWXRJndg3SwAo9dVwAAAGIJAeRKg",
+  "error_code":"KOE320"
+}


### PR DESCRIPTION
## 개요
- close #28 

## 작업사항
- 글로벌 에러코드 사용해서 
- 전체 로직에 비즈니스 에러 적용했숩니다.
- 유저 도메인 에러코드 적용했습니당
- 카카오 kauth 랑 info feign 클라이언트 에러 디코더 적용했습니다.
- 스웨거에 예시 응답 에러코드 나열했습니다


혹시 빠트린에러 있으면 함 말씀해주셔유
![무제](https://github.com/depromeet/Whatnow-Api/assets/13329304/3507d351-be5a-47c7-9101-684b9f55aca5)


## 변경로직
- 내용을 적어주세요.