### PR TITLE
[DPMBE-51] NCP Object Storage PresignedUrl 업로드 기능을 개발한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -21,7 +21,7 @@ class ImageController(
     val getPresignedUrlUseCase: GetPresignedUrlUseCase,
 ) {
     @Operation(summary = "약속 관련 이미지 업로드 Presigned URL 발급")
-    @GetMapping("/promise/{promiseId}/images")
+    @GetMapping("/promises/{promiseId}/images")
     fun getPresignedUrlOfPromise(
         @PathVariable promiseId: Long,
         @RequestParam fileExtension: ImageFileExtension,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -1,17 +1,11 @@
 package com.depromeet.whatnow.api.image.controller
 
-import com.amazonaws.HttpMethod
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.Headers
-import com.amazonaws.services.s3.model.CannedAccessControlList
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,13 +18,13 @@ import java.util.*
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
 class ImageController(
-    val getPresignedUrlUseCase: GetPresignedUrlUseCase
+    val getPresignedUrlUseCase: GetPresignedUrlUseCase,
 ) {
     @Operation(summary = "약속 관련 이미지 업로드 Presigned URL 발급")
     @GetMapping("/promise/{promiseId}/images")
     fun getPresignedUrlOfPromise(
         @PathVariable promiseId: Long,
-        @RequestParam fileExtension: ImageFileExtension
+        @RequestParam fileExtension: ImageFileExtension,
     ): ImageUrlResponse {
         return getPresignedUrlUseCase.forPromise(promiseId, fileExtension)
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -1,0 +1,37 @@
+package com.depromeet.whatnow.api.image.controller
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.Headers
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
+import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
+import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@Tag(name = "6. [이미지]")
+@RequestMapping("/v1")
+@SecurityRequirement(name = "access-token")
+class ImageController(
+    val getPresignedUrlUseCase: GetPresignedUrlUseCase
+) {
+    @Operation(summary = "약속 관련 이미지 업로드 Presigned URL 발급")
+    @GetMapping("/promise/{promiseId}/images")
+    fun getPresignedUrlOfPromise(
+        @PathVariable promiseId: Long,
+        @RequestParam fileExtension: ImageFileExtension
+    ): ImageUrlResponse {
+        return getPresignedUrlUseCase.forPromise(promiseId, fileExtension)
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageUrlResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageUrlResponse.kt
@@ -4,13 +4,13 @@ import com.depromeet.whatnow.config.s3.ImageUrlDto
 
 class ImageUrlResponse(
     val presignedUrl: String,
-    val key: String
+    val key: String,
 ) {
     companion object {
         fun from(imageUrlDto: ImageUrlDto): ImageUrlResponse {
             return ImageUrlResponse(
                 presignedUrl = imageUrlDto.url,
-                key = imageUrlDto.key
+                key = imageUrlDto.key,
             )
         }
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageUrlResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageUrlResponse.kt
@@ -1,0 +1,17 @@
+package com.depromeet.whatnow.api.image.dto
+
+import com.depromeet.whatnow.config.s3.ImageUrlDto
+
+class ImageUrlResponse(
+    val presignedUrl: String,
+    val key: String
+) {
+    companion object {
+        fun from(imageUrlDto: ImageUrlDto): ImageUrlResponse {
+            return ImageUrlResponse(
+                presignedUrl = imageUrlDto.url,
+                key = imageUrlDto.key
+            )
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
@@ -1,0 +1,16 @@
+package com.depromeet.whatnow.api.image.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+import com.depromeet.whatnow.config.s3.S3UploadPresignedUrlService
+
+@UseCase
+class GetPresignedUrlUseCase(
+    val presignedUrlService: S3UploadPresignedUrlService
+) {
+    fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlResponse {
+        presignedUrlService.forPromise(promiseId, fileExtension)
+        return ImageUrlResponse.from(presignedUrlService.forPromise(promiseId, fileExtension))
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
@@ -10,7 +10,6 @@ class GetPresignedUrlUseCase(
     val presignedUrlService: S3UploadPresignedUrlService,
 ) {
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlResponse {
-        presignedUrlService.forPromise(promiseId, fileExtension)
         return ImageUrlResponse.from(presignedUrlService.forPromise(promiseId, fileExtension))
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
@@ -7,7 +7,7 @@ import com.depromeet.whatnow.config.s3.S3UploadPresignedUrlService
 
 @UseCase
 class GetPresignedUrlUseCase(
-    val presignedUrlService: S3UploadPresignedUrlService
+    val presignedUrlService: S3UploadPresignedUrlService,
 ) {
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlResponse {
         presignedUrlService.forPromise(promiseId, fileExtension)

--- a/Whatnow-Infrastructure/build.gradle.kts
+++ b/Whatnow-Infrastructure/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies{
     api ("io.github.openfeign:feign-jackson:12.1")
     api ("org.springframework.boot:spring-boot-starter-data-redis")
     api ("org.redisson:redisson:3.19.0")
+    api ("com.amazonaws:aws-java-sdk-s3:1.12.476")
 
     implementation(project(":Whatnow-Common"))
 

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/EnableConfigProperties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/EnableConfigProperties.kt
@@ -1,8 +1,9 @@
 package com.depromeet.whatnow.config
 
+import com.depromeet.whatnow.config.s3.S3Properties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
-@EnableConfigurationProperties(OauthProperties::class)
+@EnableConfigurationProperties(OauthProperties::class, S3Properties::class)
 @Configuration
 class EnableConfigProperties

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
@@ -3,7 +3,8 @@ package com.depromeet.whatnow.config.s3
 enum class ImageFileExtension(uploadExtension: String) {
     JPEG("jpeg"),
     JPG("jpg"),
-    PNG("png")
+    PNG("png"),
+    ;
 
-    val uploadExtension = uploadExtension,
+    val uploadExtension = uploadExtension
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.config.s3
 enum class ImageFileExtension(uploadExtension: String) {
     JPEG("jpeg"),
     JPG("jpg"),
-    PNG("png");
+    PNG("png")
 
-    val uploadExtension = uploadExtension
+    val uploadExtension = uploadExtension,
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageFileExtension.kt
@@ -1,0 +1,9 @@
+package com.depromeet.whatnow.config.s3
+
+enum class ImageFileExtension(uploadExtension: String) {
+    JPEG("jpeg"),
+    JPG("jpg"),
+    PNG("png");
+
+    val uploadExtension = uploadExtension
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageUrlDto.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageUrlDto.kt
@@ -1,0 +1,6 @@
+package com.depromeet.whatnow.config.s3
+
+class ImageUrlDto(
+    val url: String,
+    val key: String
+)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageUrlDto.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/ImageUrlDto.kt
@@ -2,5 +2,5 @@ package com.depromeet.whatnow.config.s3
 
 class ImageUrlDto(
     val url: String,
-    val key: String
+    val key: String,
 )

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
@@ -21,7 +21,7 @@ class S3Config(
     val region: String,
 
     @Value("\${ncp.s3.endpoint}")
-    val endPoint: String
+    val endPoint: String,
 ) {
     @Bean
     fun amazonS3(): AmazonS3 {

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
@@ -1,0 +1,33 @@
+package com.depromeet.whatnow.config.s3
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class S3Configs(
+    @Value("\${ncp.s3.access-key}")
+    val accessKey: String,
+
+    @Value("\${ncp.s3.secret-key}")
+    val secretKey: String,
+
+    @Value("\${ncp.s3.region}")
+    val region: String,
+
+    @Value("\${ncp.s3.endpoint}")
+    val endPoint: String
+) {
+    @Bean
+    fun amazonS3(): AmazonS3 {
+        return AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(endPoint, region))
+            .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretKey)))
+            .build()
+    }
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class S3Configs(
+class S3Config(
     @Value("\${ncp.s3.access-key}")
     val accessKey: String,
 

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Config.kt
@@ -5,29 +5,20 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class S3Config(
-    @Value("\${ncp.s3.access-key}")
-    val accessKey: String,
-
-    @Value("\${ncp.s3.secret-key}")
-    val secretKey: String,
-
-    @Value("\${ncp.s3.region}")
-    val region: String,
-
-    @Value("\${ncp.s3.endpoint}")
-    val endPoint: String,
+    s3Properties: S3Properties,
 ) {
+    val s3Secret: S3Properties.S3Secret = s3Properties.s3
+
     @Bean
     fun amazonS3(): AmazonS3 {
         return AmazonS3ClientBuilder.standard()
-            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(endPoint, region))
-            .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretKey)))
+            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(s3Secret.endpoint, s3Secret.region))
+            .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(s3Secret.accessKey, s3Secret.secretKey)))
             .build()
     }
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
@@ -13,6 +13,6 @@ data class S3Properties(
         val secretKey: String,
         val region: String,
         val endpoint: String,
-        val bucket: String
+        val bucket: String,
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
@@ -6,12 +6,12 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConfigurationProperties(prefix = "ncp")
 @ConstructorBinding
 class S3Properties(
-    val s3: S3Secret
+    val s3: S3Secret,
 ) {
     data class S3Secret(
         val accessKey: String,
         val secretKey: String,
         val region: String,
-        val endpoint: String
+        val endpoint: String,
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
 
 @ConfigurationProperties(prefix = "ncp")
 @ConstructorBinding
-class S3Properties(
+data class S3Properties(
     val s3: S3Secret,
 ) {
     data class S3Secret(
@@ -13,5 +13,6 @@ class S3Properties(
         val secretKey: String,
         val region: String,
         val endpoint: String,
+        val bucket: String
     )
 }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Properties.kt
@@ -1,0 +1,17 @@
+package com.depromeet.whatnow.config.s3
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(prefix = "ncp")
+@ConstructorBinding
+class S3Properties(
+    val s3: S3Secret
+) {
+    data class S3Secret(
+        val accessKey: String,
+        val secretKey: String,
+        val region: String,
+        val endpoint: String
+    )
+}

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
@@ -14,7 +14,7 @@ class S3UploadPresignedUrlService(
     val amazonS3: AmazonS3,
 
     @Value("\${ncp.s3.bucket}")
-    val bucket: String
+    val bucket: String,
 ) {
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
         val uuid = UUID.randomUUID().toString()
@@ -23,7 +23,7 @@ class S3UploadPresignedUrlService(
             getGeneratePreSignedUrlRequest(bucket, fileName, fileExtension.uploadExtension)
 
         val generatePresignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest)
-        return ImageUrlDto(generatePresignedUrl.toString(),  uuid);
+        return ImageUrlDto(generatePresignedUrl.toString(), uuid)
     }
 
     private fun getForPromiseFimeName(uuid: String, promiseId: Long, fileExtension: ImageFileExtension): String {
@@ -31,14 +31,17 @@ class S3UploadPresignedUrlService(
     }
 
     private fun getGeneratePreSignedUrlRequest(
-        bucket: String, fileName: String, fileExtension: String
+        bucket: String,
+        fileName: String,
+        fileExtension: String,
     ): GeneratePresignedUrlRequest {
-        val generatePresignedUrlRequest = GeneratePresignedUrlRequest(bucket, fileName , HttpMethod.PUT)
+        val generatePresignedUrlRequest = GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
             .withKey(fileName)
             .withContentType("image/$fileExtension")
             .withExpiration(getPreSignedUrlExpiration())
         generatePresignedUrlRequest.addRequestParameter(
-            Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString()
+            Headers.S3_CANNED_ACL,
+            CannedAccessControlList.PublicRead.toString(),
         )
         return generatePresignedUrlRequest
     }

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
@@ -5,22 +5,21 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.Headers
 import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
 class S3UploadPresignedUrlService(
     val amazonS3: AmazonS3,
-
-    @Value("\${ncp.s3.bucket}")
-    val bucket: String,
+    s3Properties: S3Properties
 ) {
+    val s3Secret: S3Properties.S3Secret = s3Properties.s3
+
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
         val uuid = UUID.randomUUID().toString()
         var fileName = getForPromiseFimeName(uuid, promiseId, fileExtension)
         val generatePresignedUrlRequest =
-            getGeneratePreSignedUrlRequest(bucket, fileName, fileExtension.uploadExtension)
+            getGeneratePreSignedUrlRequest(s3Secret.bucket, fileName, fileExtension.uploadExtension)
 
         val generatePresignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest)
         return ImageUrlDto(generatePresignedUrl.toString(), uuid)

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
@@ -11,7 +11,7 @@ import java.util.*
 @Service
 class S3UploadPresignedUrlService(
     val amazonS3: AmazonS3,
-    s3Properties: S3Properties
+    s3Properties: S3Properties,
 ) {
     val s3Secret: S3Properties.S3Secret = s3Properties.s3
 

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlService.kt
@@ -1,0 +1,53 @@
+package com.depromeet.whatnow.config.s3
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.Headers
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class S3UploadPresignedUrlService(
+    val amazonS3: AmazonS3,
+
+    @Value("\${ncp.s3.bucket}")
+    val bucket: String
+) {
+    fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
+        val uuid = UUID.randomUUID().toString()
+        var fileName = getForPromiseFimeName(uuid, promiseId, fileExtension)
+        val generatePresignedUrlRequest =
+            getGeneratePreSignedUrlRequest(bucket, fileName, fileExtension.uploadExtension)
+
+        val generatePresignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest)
+        return ImageUrlDto(generatePresignedUrl.toString(),  uuid);
+    }
+
+    private fun getForPromiseFimeName(uuid: String, promiseId: Long, fileExtension: ImageFileExtension): String {
+        return "promise/" + promiseId + "/" + uuid + "." + fileExtension.uploadExtension
+    }
+
+    private fun getGeneratePreSignedUrlRequest(
+        bucket: String, fileName: String, fileExtension: String
+    ): GeneratePresignedUrlRequest {
+        val generatePresignedUrlRequest = GeneratePresignedUrlRequest(bucket, fileName , HttpMethod.PUT)
+            .withKey(fileName)
+            .withContentType("image/$fileExtension")
+            .withExpiration(getPreSignedUrlExpiration())
+        generatePresignedUrlRequest.addRequestParameter(
+            Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString()
+        )
+        return generatePresignedUrlRequest
+    }
+
+    private fun getPreSignedUrlExpiration(): Date {
+        val expiration = Date()
+        var expTimeMillis = expiration.time
+        expTimeMillis += 1000 * 60 * 30
+        expiration.time = expTimeMillis
+        return expiration
+    }
+}

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -25,6 +25,13 @@ feign:
   kakao:
     info : https://kapi.kakao.com
     oauth : https://kauth.kakao.com
+ncp:
+  s3:
+    access-key: ${NCP_ACCESS_KEY:}
+    secret-key: ${NCP_SECRET_KEY:}
+    bucket: ${NCP_BUCKET:}
+    region: ${NCP_REGION:}
+    endpoint: ${NCP_ENDPOINT:}
 #ncp:
 #  service-id: ${NCP_SERVICE_ID:}
 #  access-key: ${NCP_ACCESS_KEY:}

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -27,11 +27,11 @@ feign:
     oauth : https://kauth.kakao.com
 ncp:
   s3:
-    access-key: ${NCP_ACCESS_KEY:}
-    secret-key: ${NCP_SECRET_KEY:}
-    bucket: ${NCP_BUCKET:}
-    region: ${NCP_REGION:}
-    endpoint: ${NCP_ENDPOINT:}
+    access-key: ${NCP_ACCESS_KEY}
+    secret-key: ${NCP_SECRET_KEY}
+    bucket: ${NCP_BUCKET}
+    region: ${NCP_REGION}
+    endpoint: ${NCP_ENDPOINT:https://kr.object.ncloudstorage.com}
 #ncp:
 #  service-id: ${NCP_SERVICE_ID:}
 #  access-key: ${NCP_ACCESS_KEY:}


### PR DESCRIPTION
## 개요
- close #53

## 작업사항
- NCP Object Storage에 PresignedUrl을 사용하여 업로드하는 기능을 추가하였습니다.
- application-infrastructure에서 사용되는 s3 환경변수 추가하여야합니다.
![image](https://github.com/depromeet/Whatnow-Api/assets/64088250/e7833ad6-ede9-4342-b89c-936d5e06863d)
- expiration 30분으로 지정해주었습니다.
- Swagger에 Tag명을 6번으로 지정해주었습니다 `6. [이미지]`

## 변경로직
- EnableConfigProperties 파일에 S3Properties 추가