### PR TITLE
[DPMBE-55] feat : 회원가입,로그인 및 fcm 토큰 업데이트 기능 추가

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/controller/AuthController.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.api.auth.controller
 
+import com.depromeet.whatnow.api.auth.dto.request.LoginRequest
 import com.depromeet.whatnow.api.auth.dto.request.RegisterRequest
 import com.depromeet.whatnow.api.auth.dto.response.AbleRegisterResponse
 import com.depromeet.whatnow.api.auth.dto.response.OauthLoginLinkResponse
@@ -87,8 +88,10 @@ class AuthController(
     @PostMapping("/oauth/kakao/login")
     fun kakaoOauthUserLogin(
         @RequestParam("id_token") token: String,
+        @Valid @RequestBody
+        loginRequest: LoginRequest,
     ): TokenAndUserResponse {
-        return loginUseCase.execute(token)
+        return loginUseCase.execute(token, loginRequest)
     }
 
     @Operation(summary = "refreshToken 용입니다.")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/request/LoginRequest.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/request/LoginRequest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.auth.dto.request
+
+data class LoginRequest(
+    val fcmToken: String,
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/request/RegisterRequest.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/request/RegisterRequest.kt
@@ -5,4 +5,6 @@ data class RegisterRequest(
     val profileImage: String,
     val isDefaultImage: Boolean,
     val username: String,
+    val fcmToken: String,
+    val appAlarm: Boolean,
 )

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/LoginUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/LoginUseCase.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.auth.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.auth.dto.request.LoginRequest
 import com.depromeet.whatnow.api.auth.dto.response.TokenAndUserResponse
 import com.depromeet.whatnow.api.auth.helper.KakaoOauthHelper
 import com.depromeet.whatnow.api.auth.usecase.helper.TokenGenerateHelper
@@ -14,9 +15,9 @@ class LoginUseCase(
     val userDomainService: UserDomainService,
     val tokenGenerateHelper: TokenGenerateHelper,
 ) {
-    fun execute(idToken: String): TokenAndUserResponse {
+    fun execute(idToken: String, loginRequest: LoginRequest): TokenAndUserResponse {
         val oauthInfo: OauthInfo = kakaoOauthHelper.getOauthInfoByIdToken(idToken)
-        val user: User = userDomainService.loginUser(oauthInfo)
+        val user: User = userDomainService.loginUser(oauthInfo, loginRequest.fcmToken)
         return tokenGenerateHelper.execute(user)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/RefreshUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/RefreshUseCase.kt
@@ -28,7 +28,7 @@ class RefreshUseCase(
             jwtTokenHelper.parseRefreshToken(refreshToken)
         val user: User = userAdapter.queryUser(refreshUserId)
         // 리프레쉬 시에도 last로그인 정보 업데이트
-        userDomainService.loginUser(user.oauthInfo)
+        userDomainService.refreshUser(user.oauthInfo)
         return tokenGenerateHelper.execute(user) // 리프레쉬 토큰도 새로고침해서 내려줍니다.
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/RegisterUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/usecase/RegisterUserUseCase.kt
@@ -53,7 +53,15 @@ class RegisterUserUseCase(
      */
     fun registerUserByOCIDToken(idToken: String, registerRequest: RegisterRequest): TokenAndUserResponse {
         val oauthInfo = kakaoOauthHelper.getOauthInfoByIdToken(idToken)
-        val user: User = userDomainService.registerUser(registerRequest.username, registerRequest.profileImage, registerRequest.isDefaultImage, oauthInfo, oauthInfo.oauthId)
+        val user: User = userDomainService.registerUser(
+            registerRequest.username,
+            registerRequest.profileImage,
+            registerRequest.isDefaultImage,
+            oauthInfo,
+            oauthInfo.oauthId,
+            registerRequest.fcmToken,
+            registerRequest.appAlarm,
+        )
 
         return tokenGenerateHelper.execute(user)
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/controller/UserController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/controller/UserController.kt
@@ -1,11 +1,12 @@
 package com.depromeet.whatnow.api.user.controller
 
-import com.depromeet.whatnow.api.auth.usecase.RegisterUserUseCase
 import com.depromeet.whatnow.api.user.usecase.ReadUserUseCase
+import com.depromeet.whatnow.api.user.usecase.UpdateUserUseCase
 import com.depromeet.whatnow.domains.user.domain.User
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,12 +15,17 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "2. [유저]")
 @SecurityRequirement(name = "access-token")
 class UserController(
-    val registerUserUseCase: RegisterUserUseCase,
     val readUserUseCase: ReadUserUseCase,
+    val updateUserUseCase: UpdateUserUseCase,
 ) {
 
     @GetMapping("/me")
     fun getMyUserInfo(): User {
         return readUserUseCase.findUser()
+    }
+
+    @PatchMapping("/alarm")
+    fun toggleAppAlarmState(): User {
+        return updateUserUseCase.toggleAppAlarmState()
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/controller/UserController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/controller/UserController.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.api.user.controller
 
+import com.depromeet.whatnow.api.user.dto.request.UpdateFcmTokenRequest
 import com.depromeet.whatnow.api.user.usecase.ReadUserUseCase
 import com.depromeet.whatnow.api.user.usecase.UpdateUserUseCase
 import com.depromeet.whatnow.domains.user.domain.User
@@ -7,8 +8,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/v1/users")
@@ -27,5 +30,13 @@ class UserController(
     @PatchMapping("/alarm")
     fun toggleAppAlarmState(): User {
         return updateUserUseCase.toggleAppAlarmState()
+    }
+
+    @PatchMapping("/fcm-token")
+    fun updateFcmToken(
+        @Valid @RequestBody
+        updateFcmTokenRequest: UpdateFcmTokenRequest,
+    ): User {
+        return updateUserUseCase.updateFcmToken(updateFcmTokenRequest)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateFcmTokenRequest.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateFcmTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.user.dto.request
+
+data class UpdateFcmTokenRequest(
+    val fcmToken: String,
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/ReadUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/ReadUserUseCase.kt
@@ -2,16 +2,15 @@ package com.depromeet.whatnow.api.user.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
 import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.user.adapter.UserAdapter
 import com.depromeet.whatnow.domains.user.domain.User
-import com.depromeet.whatnow.domains.user.repository.UserRepository
-import org.springframework.data.repository.findByIdOrNull
 
 @UseCase
 class ReadUserUseCase(
-    val userRepository: UserRepository,
+    val userAdapter: UserAdapter,
 ) {
     fun findUser(): User {
         val currentUserId: Long = SecurityUtils.currentUserId
-        return userRepository.findByIdOrNull(currentUserId)!!
+        return userAdapter.queryUser(currentUserId)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.user.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.user.dto.request.UpdateFcmTokenRequest
 import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.service.UserDomainService
@@ -12,5 +13,10 @@ class UpdateUserUseCase(
     fun toggleAppAlarmState(): User {
         val currentUserId: Long = SecurityUtils.currentUserId
         return userDomainService.toggleAppAlarmState(currentUserId)
+    }
+
+    fun updateFcmToken(updateTokenRequest: UpdateFcmTokenRequest): User {
+        val currentUserId: Long = SecurityUtils.currentUserId
+        return userDomainService.updateFcmToken(currentUserId, updateTokenRequest.fcmToken)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
@@ -1,0 +1,16 @@
+package com.depromeet.whatnow.api.user.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.service.UserDomainService
+
+@UseCase
+class UpdateUserUseCase(
+    val userDomainService: UserDomainService,
+) {
+    fun toggleAppAlarmState(): User {
+        val currentUserId: Long = SecurityUtils.currentUserId
+        return userDomainService.toggleAppAlarmState(currentUserId)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
@@ -19,4 +19,8 @@ class UserAdapter(
     fun queryByOauthInfo(oauthInfo: OauthInfo): User {
         return userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
     }
+
+    fun save(user: User): User {
+        return userRepository.save(user)
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.user.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
+import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.exception.UserNotFoundException
 import com.depromeet.whatnow.domains.user.repository.UserRepository
@@ -13,5 +14,9 @@ class UserAdapter(
 
     fun queryUser(userId: Long): User {
         return userRepository.findByIdOrNull(userId) ?: run { throw UserNotFoundException.EXCEPTION }
+    }
+
+    fun queryByOauthInfo(oauthInfo: OauthInfo): User {
+        return userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
@@ -10,6 +10,9 @@ class FcmNotificationVo(
 ) {
 
     companion object {
+        fun toggleAlarm(originalState: FcmNotificationVo): FcmNotificationVo {
+            return FcmNotificationVo(originalState.fcmToken, originalState.appAlarm.not())
+        }
         fun disableAlarm(originalState: FcmNotificationVo): FcmNotificationVo {
             return FcmNotificationVo(originalState.fcmToken, false)
         }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
@@ -1,0 +1,25 @@
+package com.depromeet.whatnow.domains.user.domain
+
+import javax.persistence.Embeddable
+
+@Embeddable
+class FcmNotificationVo(
+    var fcmToken: String = "",
+
+    var appAlarm : Boolean,
+    ) {
+
+    companion object {
+        fun disableAlarm(originalState : FcmNotificationVo) : FcmNotificationVo {
+            return FcmNotificationVo(originalState.fcmToken,false)
+        }
+
+        fun deleteToken(originalState : FcmNotificationVo) : FcmNotificationVo {
+            return FcmNotificationVo("", originalState.appAlarm)
+        }
+
+        fun updateToken(originalState: FcmNotificationVo,fcmToken: String) : FcmNotificationVo{
+            return FcmNotificationVo(fcmToken,originalState.appAlarm)
+        }
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/FcmNotificationVo.kt
@@ -6,20 +6,20 @@ import javax.persistence.Embeddable
 class FcmNotificationVo(
     var fcmToken: String = "",
 
-    var appAlarm : Boolean,
-    ) {
+    var appAlarm: Boolean,
+) {
 
     companion object {
-        fun disableAlarm(originalState : FcmNotificationVo) : FcmNotificationVo {
-            return FcmNotificationVo(originalState.fcmToken,false)
+        fun disableAlarm(originalState: FcmNotificationVo): FcmNotificationVo {
+            return FcmNotificationVo(originalState.fcmToken, false)
         }
 
-        fun deleteToken(originalState : FcmNotificationVo) : FcmNotificationVo {
+        fun deleteToken(originalState: FcmNotificationVo): FcmNotificationVo {
             return FcmNotificationVo("", originalState.appAlarm)
         }
 
-        fun updateToken(originalState: FcmNotificationVo,fcmToken: String) : FcmNotificationVo{
-            return FcmNotificationVo(fcmToken,originalState.appAlarm)
+        fun updateToken(originalState: FcmNotificationVo, fcmToken: String): FcmNotificationVo {
+            return FcmNotificationVo(fcmToken, originalState.appAlarm)
         }
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -80,4 +80,8 @@ class User(
         }
         lastLoginAt = LocalDateTime.now()
     }
+
+    fun toggleAppAlarmState() {
+        fcmNotification = FcmNotificationVo.toggleAlarm(fcmNotification)
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -73,4 +73,11 @@ class User(
     private fun updateToken(fcmToken: String) {
         fcmNotification = FcmNotificationVo.updateToken(this.fcmNotification, fcmToken)
     }
+
+    fun refresh() {
+        if (status != UserStatus.NORMAL) {
+            throw ForbiddenUserException.EXCEPTION
+        }
+        lastLoginAt = LocalDateTime.now()
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -84,4 +84,8 @@ class User(
     fun toggleAppAlarmState() {
         fcmNotification = FcmNotificationVo.toggleAlarm(fcmNotification)
     }
+
+    fun updateFcmToken(fcmToken: String) {
+        fcmNotification = FcmNotificationVo.updateToken(fcmNotification, fcmToken)
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -29,7 +29,7 @@ class User(
     var isDefaultImg: Boolean,
 
     @Embedded
-    var fcmNotification : FcmNotificationVo,
+    var fcmNotification: FcmNotificationVo,
 
     var lastLoginAt: LocalDateTime = LocalDateTime.now(),
 
@@ -70,7 +70,7 @@ class User(
         oauthInfo = oauthInfo.withDrawOauthInfo()
     }
 
-    private fun updateToken(fcmToken : String){
-        fcmNotification = FcmNotificationVo.updateToken(this.fcmNotification,fcmToken)
+    private fun updateToken(fcmToken: String) {
+        fcmNotification = FcmNotificationVo.updateToken(this.fcmNotification, fcmToken)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -2,6 +2,8 @@ package com.depromeet.whatnow.domains.user.domain
 
 import com.depromeet.whatnow.common.BaseTimeEntity
 import com.depromeet.whatnow.common.aop.event.Events
+import com.depromeet.whatnow.domains.user.exception.AlreadyDeletedUserException
+import com.depromeet.whatnow.domains.user.exception.ForbiddenUserException
 import com.depromeet.whatnow.events.domainEvent.UserSignUpEvent
 import java.time.LocalDateTime
 import javax.persistence.Column
@@ -26,9 +28,10 @@ class User(
     var profileImg: String, // 프로필 이미지도 vo 로 빼면 더 이쁠듯
     var isDefaultImg: Boolean,
 
-    var lastLoginAt: LocalDateTime = LocalDateTime.now(),
+    @Embedded
+    var fcmNotification : FcmNotificationVo,
 
-    var fcmToken: String = "", // vo 로 빼서 알림 수신여부 까지 같이 관리하면 그림이 더 이쁠듯 합니다.
+    var lastLoginAt: LocalDateTime = LocalDateTime.now(),
 
     @Enumerated(EnumType.STRING)
     var status: UserStatus = UserStatus.NORMAL,
@@ -48,21 +51,26 @@ class User(
         Events.raise(UserSignUpEvent(this.id!!))
     }
 
-    fun login() {
+    fun login(fcmToken: String) {
         if (status != UserStatus.NORMAL) {
-//            throw ForbiddenUserException.EXCEPTION
+            throw ForbiddenUserException.EXCEPTION
         }
         lastLoginAt = LocalDateTime.now()
+        updateToken(fcmToken) // 로그인시에 토큰 업데이트
     }
 
     fun withDraw() {
         if (status == UserStatus.DELETED) {
-//            throw AlreadyDeletedUserException.EXCEPTION
+            throw AlreadyDeletedUserException.EXCEPTION
         }
         status = UserStatus.DELETED
         nickname = "탈퇴유저"
         profileImg = ""
-        fcmToken = ""
+        fcmNotification = FcmNotificationVo.disableAlarm(this.fcmNotification)
         oauthInfo = oauthInfo.withDrawOauthInfo()
+    }
+
+    private fun updateToken(fcmToken : String){
+        fcmNotification = FcmNotificationVo.updateToken(this.fcmNotification,fcmToken)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -74,4 +74,11 @@ class UserDomainService(
         val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw UserNotFoundException.EXCEPTION }
         user.withDraw()
     }
+
+    @Transactional
+    fun toggleAppAlarmState(currentUserId: Long): User {
+        val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw UserNotFoundException.EXCEPTION }
+        user.toggleAppAlarmState()
+        return user
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.user.service
 
 import com.depromeet.whatnow.annotation.DomainService
+import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.exception.AlreadySignUpUserException
@@ -27,7 +28,7 @@ class UserDomainService(
         oauthId: String,
     ): User {
         return userRepository.findByOauthInfo(oauthInfo) ?: run {
-            val newUser = userRepository.save(User(oauthInfo, username, profileImage, defaultImage))
+            val newUser = userRepository.save(User(oauthInfo, username, profileImage, defaultImage,FcmNotificationVo("", false)))
             newUser.registerEvent()
             return newUser
         }
@@ -38,15 +39,17 @@ class UserDomainService(
         return true
     }
 
-    fun registerUser(username: String, profileImage: String, defaultImage: Boolean, oauthInfo: OauthInfo, oauthId: String): User {
+    fun registerUser(username: String, profileImage: String, defaultImage: Boolean, oauthInfo: OauthInfo, oauthId: String,fcmToken: String,appAlarm: Boolean): User {
         userRepository.findByOauthInfo(oauthInfo)?. let { throw AlreadySignUpUserException.EXCEPTION }
-        return userRepository.save(User(oauthInfo, username, profileImage, defaultImage))
+        return userRepository.save(User(oauthInfo, username, profileImage, defaultImage,
+            FcmNotificationVo(fcmToken, appAlarm)
+        ))
     }
 
     @Transactional
-    fun loginUser(oauthInfo: OauthInfo): User {
+    fun loginUser(oauthInfo: OauthInfo, fcmToken : String): User {
         val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
-        user.login()
+        user.login(fcmToken)
         return user
     }
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -59,6 +59,16 @@ class UserDomainService(
         return user
     }
 
+    /**
+     * 유저가 리프레쉬 할때 ( 클라이언트와 fcm 토큰 업데이트는 로그인 회원가입 할 때만 하기로 합의 )
+     */
+    @Transactional
+    fun refreshUser(oauthInfo: OauthInfo): User {
+        val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
+        user.refresh()
+        return user
+    }
+
     @Transactional
     fun withDrawUser(currentUserId: Long) {
         val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw UserNotFoundException.EXCEPTION }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -28,7 +28,7 @@ class UserDomainService(
         oauthId: String,
     ): User {
         return userRepository.findByOauthInfo(oauthInfo) ?: run {
-            val newUser = userRepository.save(User(oauthInfo, username, profileImage, defaultImage,FcmNotificationVo("", false)))
+            val newUser = userRepository.save(User(oauthInfo, username, profileImage, defaultImage, FcmNotificationVo("", false)))
             newUser.registerEvent()
             return newUser
         }
@@ -39,15 +39,21 @@ class UserDomainService(
         return true
     }
 
-    fun registerUser(username: String, profileImage: String, defaultImage: Boolean, oauthInfo: OauthInfo, oauthId: String,fcmToken: String,appAlarm: Boolean): User {
+    fun registerUser(username: String, profileImage: String, defaultImage: Boolean, oauthInfo: OauthInfo, oauthId: String, fcmToken: String, appAlarm: Boolean): User {
         userRepository.findByOauthInfo(oauthInfo)?. let { throw AlreadySignUpUserException.EXCEPTION }
-        return userRepository.save(User(oauthInfo, username, profileImage, defaultImage,
-            FcmNotificationVo(fcmToken, appAlarm)
-        ))
+        return userRepository.save(
+            User(
+                oauthInfo,
+                username,
+                profileImage,
+                defaultImage,
+                FcmNotificationVo(fcmToken, appAlarm),
+            ),
+        )
     }
 
     @Transactional
-    fun loginUser(oauthInfo: OauthInfo, fcmToken : String): User {
+    fun loginUser(oauthInfo: OauthInfo, fcmToken: String): User {
         val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
         user.login(fcmToken)
         return user

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -15,6 +15,13 @@ class UserDomainService(
     val userAdapter: UserAdapter,
 ) {
 
+    /**
+     * https://toss.tech/article/kotlin-result
+     * 레포지토리에서 가져오던걸 어떻게 리팩토링 할 까 고민하다가 좋은 글이 있어서 공유합니다.
+     * 기본으로 query 메소드를 userAdapter로 놓고.
+     * Result 로 한번 래핑을 한뒤에, onSuccess,onFailure , getOrElse 등의 메소드를 이용해서
+     * 적절하게 대응을 할 수 있습니다. 매우 깔끔스
+     */
     fun resultQueryByOauthInfo(oauthInfo: OauthInfo): Result<User> {
         return runCatching {
             userAdapter.queryByOauthInfo(oauthInfo)

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -81,4 +81,11 @@ class UserDomainService(
         user.toggleAppAlarmState()
         return user
     }
+
+    @Transactional
+    fun updateFcmToken(currentUserId: Long, fcmToken: String): User {
+        val user = userRepository.findByIdOrNull(currentUserId) ?: run { throw UserNotFoundException.EXCEPTION }
+        user.updateFcmToken(fcmToken)
+        return user
+    }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainServiceTest.kt
@@ -1,0 +1,78 @@
+package com.depromeet.whatnow.domains.user.service
+
+import com.depromeet.whatnow.domains.user.adapter.UserAdapter
+import com.depromeet.whatnow.domains.user.exception.AlreadySignUpUserException
+import com.depromeet.whatnow.domains.user.exception.UserNotFoundException
+import com.depromeet.whatnow.helper.oauthInfo_kakao_1_fixture
+import com.depromeet.whatnow.helper.user_id_1_fixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.willReturn
+
+@ExtendWith(MockitoExtension::class)
+class UserDomainServiceTest {
+
+    @Mock
+    lateinit var userAdapter: UserAdapter
+
+    private lateinit var userDomainService: UserDomainService
+
+    @BeforeEach
+    fun setup() {
+        userDomainService = UserDomainService(userAdapter)
+    }
+
+    @Test
+    fun `유저가 회원가입한 상태면 회원가입 가능 여부가 false 가 되어야한다`() {
+        given(userAdapter.queryByOauthInfo(any())).willReturn { user_id_1_fixture() }
+        val canRegister = userDomainService.checkUserCanRegister(oauthInfo_kakao_1_fixture())
+        assertEquals(canRegister, false)
+    }
+
+    @Test
+    fun `유저가 회원가입하지 않은 상태면 회원가입 가능 여부가 true 가 되어야한다`() {
+        given(userAdapter.queryByOauthInfo(any())).willThrow(UserNotFoundException.EXCEPTION)
+        val canRegister = userDomainService.checkUserCanRegister(oauthInfo_kakao_1_fixture())
+        assertEquals(canRegister, true)
+    }
+
+    @Test
+    fun `유저가 회원가입한 상태에서 회원가입을 중복요청하면 이미 회원가입한 에러가 발생해야한다`() {
+        given(userAdapter.queryByOauthInfo(any())).willReturn { user_id_1_fixture() }
+        assertThrows(AlreadySignUpUserException::class.java) {
+            userDomainService.registerUser(
+                "username",
+                "image",
+                true,
+                oauthInfo_kakao_1_fixture(),
+                "1",
+                "fcmToken",
+                true,
+            )
+        }
+    }
+
+    @Test
+    fun `유저회원가입이 정상적으로 동작해야한다`() {
+        given(userAdapter.queryByOauthInfo(any())).willThrow(UserNotFoundException.EXCEPTION)
+        given(userAdapter.save(any())).willReturn { user_id_1_fixture() }
+
+        userDomainService.registerUser(
+            "유저1",
+            "url1",
+            true,
+            oauthInfo_kakao_1_fixture(),
+            "1",
+            "fcmToken",
+            true,
+        )
+        assertEquals(user_id_1_fixture().id, 1)
+    }
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/UserFixture.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/helper/UserFixture.kt
@@ -1,0 +1,31 @@
+package com.depromeet.whatnow.helper
+
+import com.depromeet.whatnow.domains.user.domain.AccountRole
+import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
+import com.depromeet.whatnow.domains.user.domain.OauthInfo
+import com.depromeet.whatnow.domains.user.domain.OauthProvider
+import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.domain.UserStatus
+import java.time.LocalDateTime
+
+fun user_id_1_fixture(): User {
+    return User(
+        oauthInfo_kakao_1_fixture(),
+        "유저1",
+        "url1",
+        true,
+        fcmNotificationVo_fixture(),
+        LocalDateTime.now(),
+        UserStatus.NORMAL,
+        AccountRole.USER,
+        1,
+    )
+}
+
+fun oauthInfo_kakao_1_fixture(): OauthInfo {
+    return OauthInfo("1", OauthProvider.KAKAO)
+}
+
+fun fcmNotificationVo_fixture(): FcmNotificationVo {
+    return FcmNotificationVo("fcmToken", true)
+}


### PR DESCRIPTION
## 개요
- close #66 

## 작업사항
- fcm 토큰 업데이트 관련 기능 추가했습니다.
- 앱 알림 껏다키는 토글 기능 만들었습니다.


## 변경로직
- fcmNotificationVo 만들어서 알림관련한 fcmToken, appAlarm 묶어줬어용
- login user refresh user 도메인 메소드 나눠줬습니다.
- 리프레쉬할때 fcm 토큰 업데이트 할 필요가없어서!


---
## Kotlin Result 관련

```kotlin
// case 1
 return userRepository.findByOauthInfo(oauthInfo) ?: run {
            val newUser = userRepository.save(User(oauthInfo, username, profileImage, defaultImage))
// case2
 val user = userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
```

위처럼 2가지 결과값은 같은데 에러처리를 할 때 대응할 때 달라져서 그냥
repository 에서 받아오고 있었는데

이거 없애고 싶어서

userAdapter 에 
```kotlin
  fun queryByOauthInfo(oauthInfo: OauthInfo): User {
        return userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
    }
```
위에걸 기본으로 대고

```kotlin
    fun resultQueryByOauthInfo(oauthInfo: OauthInfo): Result<User> {
        return runCatching { // runCatching 으로 감쌈
            userAdapter.queryByOauthInfo(oauthInfo)
        }
    }
```

위처럼 userDomain 서비스에서 한 번 Kotlin Result 로 래핑해서 쓰기로 했더니
좀 더 깔끔해졌어요 소스가 ㅎㅎ

- https://toss.tech/article/kotlin-result
- 곧있음 들어갈 토스페이먼츠 선배님이 쓰신글 링크검 ㅎㅎ