### PR TITLE
[DPMBE-63] 이미지 관련 테스트 코드를 작성한다

### DIFF
--- a/Whatnow-Api/build.gradle.kts
+++ b/Whatnow-Api/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
     implementation("org.springdoc:springdoc-openapi-ui:1.6.12")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.security:spring-security-test")
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.*
 
 @RestController
 @Tag(name = "6. [이미지]")

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -1,5 +1,44 @@
 package com.depromeet.whatnow.api.image.controller
 
-import org.junit.jupiter.api.Assertions.*
+import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-class ImageControllerTest
+@WebMvcTest(ImageController::class)
+@ContextConfiguration(classes = [ImageController::class])
+@AutoConfigureMockMvc
+class ImageControllerTest {
+    @MockBean
+    lateinit var getPresignedUrlUseCase: GetPresignedUrlUseCase
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    @WithMockUser(username = "test", roles = ["USER"])
+    fun `presignedUrl 요청에 성공하면 200을 응답한다`() {
+        // given
+        val promiseId = 1L
+        val fileExtension = ImageFileExtension.JPEG.name
+
+        // when, then
+        mockMvc.perform(
+            get("/v1/promises/{promiseId}/images", promiseId)
+                .param("fileExtension", fileExtension)
+                .with(user("test").roles("USER")),
+        )
+            .andExpect(status().isOk)
+            .andDo { print(it) }
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(ImageController::class)
 @ContextConfiguration(classes = [ImageController::class])
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 class ImageControllerTest {
     @MockBean
     lateinit var getPresignedUrlUseCase: GetPresignedUrlUseCase
@@ -25,7 +25,6 @@ class ImageControllerTest {
     lateinit var mockMvc: MockMvc
 
     @Test
-    @WithMockUser(username = "test", roles = ["USER"])
     fun `presignedUrl 요청에 성공하면 200을 응답한다`() {
         // given
         val promiseId = 1L
@@ -35,7 +34,6 @@ class ImageControllerTest {
         mockMvc.perform(
             get("/v1/promises/{promiseId}/images", promiseId)
                 .param("fileExtension", fileExtension)
-                .with(user("test").roles("USER")),
         )
             .andExpect(status().isOk)
             .andDo { print(it) }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.image.controller
+
+import org.junit.jupiter.api.Assertions.*
+
+class ImageControllerTest

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -33,7 +31,7 @@ class ImageControllerTest {
         // when, then
         mockMvc.perform(
             get("/v1/promises/{promiseId}/images", promiseId)
-                .param("fileExtension", fileExtension)
+                .param("fileExtension", fileExtension),
         )
             .andExpect(status().isOk)
             .andDo { print(it) }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -2,7 +2,6 @@ package com.depromeet.whatnow.api.image.controller
 
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
@@ -22,11 +22,6 @@ class GetPresignedUrlUseCaseTest {
     @Test
     fun `PresignUrl 을 요청하면 url 을 반환한다`() {
         // given
-        ImageUrlDto(
-            url = "https://whatnow.kr/1.jpg",
-            key = "1.jpg",
-        )
-
         given(presignedUrlService.forPromise(1, ImageFileExtension.JPEG)).willReturn(
             ImageUrlDto(
                 url = "https://whatnow.kr/1.jpg",

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
@@ -1,5 +1,43 @@
 package com.depromeet.whatnow.api.image.usecase
 
-import org.junit.jupiter.api.Assertions.*
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+import com.depromeet.whatnow.config.s3.ImageUrlDto
+import com.depromeet.whatnow.config.s3.S3UploadPresignedUrlService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
 
-class GetPresignedUrlUseCaseTest
+@ExtendWith(MockitoExtension::class)
+class GetPresignedUrlUseCaseTest {
+    @Mock
+    lateinit var presignedUrlService: S3UploadPresignedUrlService
+
+    @InjectMocks
+    lateinit var getPresignedUrlUseCase: GetPresignedUrlUseCase
+
+    @Test
+    fun `PresignUrl 을 요청하면 url 을 반환한다`() {
+        // given
+        ImageUrlDto(
+            url = "https://whatnow.kr/1.jpg",
+            key = "1.jpg",
+        )
+
+        given(presignedUrlService.forPromise(1, ImageFileExtension.JPEG)).willReturn(
+            ImageUrlDto(
+                url = "https://whatnow.kr/1.jpg",
+                key = "1.jpg",
+            ),
+        )
+        // when
+        val imageUrlResponse = getPresignedUrlUseCase.forPromise(1, ImageFileExtension.JPEG)
+
+        // then
+        assertEquals("https://whatnow.kr/1.jpg", imageUrlResponse.presignedUrl)
+        assertEquals("1.jpg", imageUrlResponse.key)
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.image.usecase
+
+import org.junit.jupiter.api.Assertions.*
+
+class GetPresignedUrlUseCaseTest

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/controller/PictureControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/controller/PictureControllerTest.kt
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -16,7 +14,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(PictureController::class)
 @ContextConfiguration(classes = [PictureController::class])
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 class PictureControllerTest {
     @MockBean
     lateinit var successUseCase: PictureUploadSuccessUseCase
@@ -25,7 +23,6 @@ class PictureControllerTest {
     lateinit var mockMvc: MockMvc
 
     @Test
-    @WithMockUser(username = "test", roles = ["USER"])
     fun `이미지 업로드 성공 요청에 정상적으로 200을 반환한다`() {
         // given
         val promiseId = 1
@@ -35,8 +32,7 @@ class PictureControllerTest {
         // when, then
         mockMvc.perform(
             post("/v1/promises/{promiseId}/images/success/{imageKey}", promiseId, imageKey)
-                .param("pictureCommentType", pictureCommentType.name)
-                .with(user("test").roles("USER")),
+                .param("pictureCommentType", pictureCommentType.name),
         )
             .andExpect(status().isOk)
             .andDo { print(it) }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/controller/PictureControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/controller/PictureControllerTest.kt
@@ -1,0 +1,44 @@
+package com.depromeet.whatnow.api.picture.controller
+
+import com.depromeet.whatnow.api.picture.usecase.PictureUploadSuccessUseCase
+import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(PictureController::class)
+@ContextConfiguration(classes = [PictureController::class])
+@AutoConfigureMockMvc
+class PictureControllerTest {
+    @MockBean
+    lateinit var successUseCase: PictureUploadSuccessUseCase
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    @WithMockUser(username = "test", roles = ["USER"])
+    fun `이미지 업로드 성공 요청에 정상적으로 200을 반환한다`() {
+        // given
+        val promiseId = 1
+        val imageKey = "imageKey"
+        val pictureCommentType = PictureCommentType.SORRY_LATE
+
+        // when, then
+        mockMvc.perform(
+            post("/v1/promises/{promiseId}/images/success/{imageKey}", promiseId, imageKey)
+                .param("pictureCommentType", pictureCommentType.name)
+                .with(user("test").roles("USER")),
+        )
+            .andExpect(status().isOk)
+            .andDo { print(it) }
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/usecase/PictureUploadSuccessUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/usecase/PictureUploadSuccessUseCaseTest.kt
@@ -1,29 +1,22 @@
 package com.depromeet.whatnow.api.picture.usecase
 
-import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
 import com.depromeet.whatnow.domains.picture.service.PictureDomainService
 import org.assertj.core.api.Assertions.assertThatCode
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.BDDMockito.given
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.test.context.support.WithMockUser
 
 @ExtendWith(MockitoExtension::class)
 class PictureUploadSuccessUseCaseTest {
     @Mock
     lateinit var pictureDomainService: PictureDomainService
-
 
     @InjectMocks
     lateinit var pictureUploadSuccessUseCase: PictureUploadSuccessUseCase

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/usecase/PictureUploadSuccessUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/picture/usecase/PictureUploadSuccessUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.depromeet.whatnow.api.picture.usecase
+
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
+import com.depromeet.whatnow.domains.picture.service.PictureDomainService
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithMockUser
+
+@ExtendWith(MockitoExtension::class)
+class PictureUploadSuccessUseCaseTest {
+    @Mock
+    lateinit var pictureDomainService: PictureDomainService
+
+
+    @InjectMocks
+    lateinit var pictureUploadSuccessUseCase: PictureUploadSuccessUseCase
+
+    @BeforeEach
+    fun setup() {
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        val authentication = UsernamePasswordAuthenticationToken("1", null, setOf(SimpleGrantedAuthority("ROLE_USER")))
+        securityContext.authentication = authentication
+        SecurityContextHolder.setContext(securityContext)
+    }
+
+    @Test
+    fun `이미지 업로드 성공 요청시 정상적이라면 에러가 발생하지 않는다`() {
+        // given
+
+        // when
+
+        // then
+        assertThatCode {
+            pictureUploadSuccessUseCase.successUploadImage(1, "1", PictureCommentType.SORRY_LATE)
+        }.doesNotThrowAnyException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapter.kt
@@ -6,7 +6,7 @@ import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
 import com.depromeet.whatnow.domains.picture.repository.PictureRepository
 
 @Adapter
-class PromiseAdapter(
+class PictureAdapter(
     val pictureRepository: PictureRepository,
 ) {
     fun save(userId: Long, promiseId: Long, imageUrl: String, imageKey: String, pictureCommentType: PictureCommentType) {

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainService.kt
@@ -1,7 +1,7 @@
 package com.depromeet.whatnow.domains.picture.service
 
 import com.depromeet.whatnow.consts.IMAGE_DOMAIN
-import com.depromeet.whatnow.domains.picture.adapter.PromiseAdapter
+import com.depromeet.whatnow.domains.picture.adapter.PictureAdapter
 import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
 import com.depromeet.whatnow.domains.picture.exception.CancelledUserUploadException
 import com.depromeet.whatnow.domains.picture.exception.InvalidCommentTypeException
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class PictureDomainService(
-    val pictureAdapter: PromiseAdapter,
+    val pictureAdapter: PictureAdapter,
     val promiseUserAdapter: PromiseUserAdaptor,
 ) {
     @Transactional
@@ -29,9 +29,9 @@ class PictureDomainService(
         when (promiseUserType) {
             PromiseUserType.READY -> throw UploadBeforeTrackingException.EXCEPTION
             PromiseUserType.CANCEL -> throw CancelledUserUploadException.EXCEPTION
-            else -> {
+            PromiseUserType.WAIT, PromiseUserType.LATE -> {
                 if (pictureCommentType.promiseUserType != promiseUserType) {
-                    InvalidCommentTypeException.EXCEPTION
+                    throw InvalidCommentTypeException.EXCEPTION
                 }
             }
         }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapterTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapterTest.kt
@@ -1,0 +1,36 @@
+package com.depromeet.whatnow.domains.picture.adapter
+
+import com.depromeet.whatnow.domains.picture.domain.Picture
+import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
+import com.depromeet.whatnow.domains.picture.repository.PictureRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import org.mockito.kotlin.then
+
+
+@ExtendWith(MockitoExtension::class)
+class PictureAdapterTest {
+    @Mock
+    lateinit var pictureRepository: PictureRepository
+
+    @InjectMocks
+    lateinit var pictureAdapter: PictureAdapter
+
+    @Test
+    fun `Picture 저장 시 정상적으로 저장된다`() {
+        val captor: ArgumentCaptor<Picture> = ArgumentCaptor.forClass(Picture::class.java)
+
+        // when
+        pictureAdapter.save(1, 1, "imageUrl", "imageKey", PictureCommentType.RUNNING)
+
+        // then
+        then(pictureRepository).should(Mockito.times(1)).save(captor.capture())
+    }
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapterTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/adapter/PictureAdapterTest.kt
@@ -3,7 +3,6 @@ package com.depromeet.whatnow.domains.picture.adapter
 import com.depromeet.whatnow.domains.picture.domain.Picture
 import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
 import com.depromeet.whatnow.domains.picture.repository.PictureRepository
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
@@ -11,9 +10,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.given
 import org.mockito.kotlin.then
-
 
 @ExtendWith(MockitoExtension::class)
 class PictureAdapterTest {

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainServiceTest.kt
@@ -2,7 +2,6 @@ package com.depromeet.whatnow.domains.picture.service
 
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.domains.picture.adapter.PictureAdapter
-import com.depromeet.whatnow.domains.picture.domain.Picture
 import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
 import com.depromeet.whatnow.domains.picture.exception.CancelledUserUploadException
 import com.depromeet.whatnow.domains.picture.exception.InvalidCommentTypeException
@@ -11,18 +10,13 @@ import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUser
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.given
-import org.mockito.kotlin.then
 
 @ExtendWith(MockitoExtension::class)
 class PictureDomainServiceTest {
@@ -42,7 +36,7 @@ class PictureDomainServiceTest {
             promiseId = 1,
             userId = 1,
             userLocation = CoordinateVo(1.0, 1.0),
-            promiseUserType = PromiseUserType.LATE
+            promiseUserType = PromiseUserType.LATE,
         )
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
@@ -60,7 +54,7 @@ class PictureDomainServiceTest {
             promiseId = 1,
             userId = 1,
             userLocation = CoordinateVo(1.0, 1.0),
-            promiseUserType = PromiseUserType.READY
+            promiseUserType = PromiseUserType.READY,
         )
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
@@ -78,7 +72,7 @@ class PictureDomainServiceTest {
             promiseId = 1,
             userId = 1,
             userLocation = CoordinateVo(1.0, 1.0),
-            promiseUserType = PromiseUserType.CANCEL
+            promiseUserType = PromiseUserType.CANCEL,
         )
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
@@ -96,7 +90,7 @@ class PictureDomainServiceTest {
             promiseId = 1,
             userId = 1,
             userLocation = CoordinateVo(1.0, 1.0),
-            promiseUserType = PromiseUserType.LATE
+            promiseUserType = PromiseUserType.LATE,
         )
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
@@ -114,7 +108,7 @@ class PictureDomainServiceTest {
             promiseId = 1,
             userId = 1,
             userLocation = CoordinateVo(1.0, 1.0),
-            promiseUserType = PromiseUserType.WAIT
+            promiseUserType = PromiseUserType.WAIT,
         )
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/picture/service/PictureDomainServiceTest.kt
@@ -1,0 +1,127 @@
+package com.depromeet.whatnow.domains.picture.service
+
+import com.depromeet.whatnow.common.vo.CoordinateVo
+import com.depromeet.whatnow.domains.picture.adapter.PictureAdapter
+import com.depromeet.whatnow.domains.picture.domain.Picture
+import com.depromeet.whatnow.domains.picture.domain.PictureCommentType
+import com.depromeet.whatnow.domains.picture.exception.CancelledUserUploadException
+import com.depromeet.whatnow.domains.picture.exception.InvalidCommentTypeException
+import com.depromeet.whatnow.domains.picture.exception.UploadBeforeTrackingException
+import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUser
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.then
+
+@ExtendWith(MockitoExtension::class)
+class PictureDomainServiceTest {
+    @Mock
+    lateinit var pictureAdapter: PictureAdapter
+
+    @Mock
+    lateinit var promiseUserAdapter: PromiseUserAdaptor
+
+    @InjectMocks
+    lateinit var pictureDomainService: PictureDomainService
+
+    @Test
+    fun `사진 업로드 성공 요청시 정상적이라면 에러를 반환하지 않는다`() {
+        // given
+        val promiseUser = PromiseUser(
+            promiseId = 1,
+            userId = 1,
+            userLocation = CoordinateVo(1.0, 1.0),
+            promiseUserType = PromiseUserType.LATE
+        )
+        given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
+            .willReturn(promiseUser)
+
+        // when, then
+        Assertions.assertThatCode {
+            pictureDomainService.successUploadImage(1, 1, "imageKey", PictureCommentType.RUNNING)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `유저가 READY 상태라면 예외가 발생한다`() {
+        // given
+        val promiseUser = PromiseUser(
+            promiseId = 1,
+            userId = 1,
+            userLocation = CoordinateVo(1.0, 1.0),
+            promiseUserType = PromiseUserType.READY
+        )
+        given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
+            .willReturn(promiseUser)
+
+        // when, then
+        Assertions.assertThatThrownBy {
+            pictureDomainService.successUploadImage(1, 1, "imageKey", PictureCommentType.RUNNING)
+        }.isInstanceOf(UploadBeforeTrackingException::class.java)
+    }
+
+    @Test
+    fun `유저가 CANCEL 상태라면 예외가 발생한다`() {
+        // given
+        val promiseUser = PromiseUser(
+            promiseId = 1,
+            userId = 1,
+            userLocation = CoordinateVo(1.0, 1.0),
+            promiseUserType = PromiseUserType.CANCEL
+        )
+        given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
+            .willReturn(promiseUser)
+
+        // when, then
+        Assertions.assertThatThrownBy {
+            pictureDomainService.successUploadImage(1, 1, "imageKey", PictureCommentType.RUNNING)
+        }.isInstanceOf(CancelledUserUploadException::class.java)
+    }
+
+    @Test
+    fun `LATE 유저가 WAIT 타입의 코멘트를 입력 할 경우 예외가 발생한다`() {
+        // given
+        val promiseUser = PromiseUser(
+            promiseId = 1,
+            userId = 1,
+            userLocation = CoordinateVo(1.0, 1.0),
+            promiseUserType = PromiseUserType.LATE
+        )
+        given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
+            .willReturn(promiseUser)
+
+        // when, then
+        Assertions.assertThatThrownBy {
+            pictureDomainService.successUploadImage(1, 1, "imageKey", PictureCommentType.DID_YOU_COME)
+        }.isInstanceOf(InvalidCommentTypeException::class.java)
+    }
+
+    @Test
+    fun `WAIT 유저가 LATE 타입의 코멘트를 입력 할 경우 예외가 발생한다`() {
+        // given
+        val promiseUser = PromiseUser(
+            promiseId = 1,
+            userId = 1,
+            userLocation = CoordinateVo(1.0, 1.0),
+            promiseUserType = PromiseUserType.WAIT
+        )
+        given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
+            .willReturn(promiseUser)
+
+        // when, then
+        Assertions.assertThatThrownBy {
+            pictureDomainService.successUploadImage(1, 1, "imageKey", PictureCommentType.WAIT_A_BIT)
+        }.isInstanceOf(InvalidCommentTypeException::class.java)
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3PropertiesTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3PropertiesTest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.config.s3
+
+import org.junit.jupiter.api.Assertions.*
+
+class S3PropertiesTest

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3PropertiesTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3PropertiesTest.kt
@@ -1,5 +1,17 @@
 package com.depromeet.whatnow.config.s3
 
-import org.junit.jupiter.api.Assertions.*
+import com.depromeet.whatnow.config.InfraIntegrateSpringBootTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 
-class S3PropertiesTest
+@InfraIntegrateSpringBootTest
+class S3PropertiesTest {
+    @Autowired
+    lateinit var s3Properties: S3Properties
+
+    @Test
+    fun `s3 프로퍼티가 제대로 init 되어야한다`() {
+        assertEquals(s3Properties.s3.endpoint, "https://kr.object.ncloudstorage.com")
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.config.s3
+
+import org.junit.jupiter.api.Assertions.*
+
+class S3UploadPresignedUrlServiceTest

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
@@ -1,5 +1,59 @@
 package com.depromeet.whatnow.config.s3
 
-import org.junit.jupiter.api.Assertions.*
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.test.assertContains
 
-class S3UploadPresignedUrlServiceTest
+@ExtendWith(MockitoExtension::class)
+class S3UploadPresignedUrlServiceTest {
+    lateinit var s3UploadPresignedUrlService: S3UploadPresignedUrlService
+
+    var s3Properties: S3Properties = S3Properties(
+        S3Properties.S3Secret(
+            accessKey = "accessKey",
+            secretKey = "secretKey",
+            region = "ap-northeast-2",
+            endpoint = "https://kr.object.ncloudstorage.com",
+            bucket = "bucket",
+        ),
+    )
+
+    var amazonS3: AmazonS3 =
+        AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(s3Properties.s3.endpoint, s3Properties.s3.region))
+            .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(s3Properties.s3.accessKey, s3Properties.s3.secretKey)))
+            .build()
+
+    @BeforeEach
+    fun setup() {
+        s3UploadPresignedUrlService = S3UploadPresignedUrlService(amazonS3, s3Properties)
+    }
+
+    @Test
+    fun `PresignedUrl을 생성한다`() {
+        // given
+        val promiseId = 1L
+        val imageFIleExtension = ImageFileExtension.JPG
+
+        // when
+        val presignedUrl = s3UploadPresignedUrlService.forPromise(promiseId, imageFIleExtension)
+
+        // then
+        val resultUrl = """
+            https:
+            //${s3Properties.s3.bucket}.${s3Properties.s3.endpoint.replace("https://", "")}
+            /promise
+            /$promiseId
+            /${presignedUrl.key}.${imageFIleExtension.uploadExtension}
+            """
+
+        assertContains(presignedUrl.url, resultUrl)
+    }
+}

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3UploadPresignedUrlServiceTest.kt
@@ -46,13 +46,7 @@ class S3UploadPresignedUrlServiceTest {
         val presignedUrl = s3UploadPresignedUrlService.forPromise(promiseId, imageFIleExtension)
 
         // then
-        val resultUrl = """
-            https:
-            //${s3Properties.s3.bucket}.${s3Properties.s3.endpoint.replace("https://", "")}
-            /promise
-            /$promiseId
-            /${presignedUrl.key}.${imageFIleExtension.uploadExtension}
-            """
+        val resultUrl = "https://${s3Properties.s3.bucket}.${s3Properties.s3.endpoint.replace("https://", "")}/promise/$promiseId/${presignedUrl.key}.${imageFIleExtension.uploadExtension}"
 
         assertContains(presignedUrl.url, resultUrl)
     }


### PR DESCRIPTION
## 개요
- close #75 

## 작업사항
- S3Properties 테스트코드 추가
- PresignUrl 관련 Controller, UseCase, Service  테스트코드 추가
- 이미지 성공적으로 올렸을때 요청하는 API UseCase, Service, Adapter 테스트코드 추가

## 변경로직
- PictureAdapter 파일명을 PromiseAdapter로 실수해버려서 수정했슴니당😥
- PictureDomainService 내의 validate 하는 부분에서 throw 키워드 누락되어 추가하였습니다

## 참고
### AutoConfigureMockMvc 관련
AutoConfigureMockMvc는 mock 테스트 시 필요한 의존성을 불러오는 어노테이션입니다.</br>
하지만 디폴트로 우리가 만든 Security Filter가 아닌 디플트로 지정된 Filter가 불러와집니다.</br>
그렇게 되면서 csrf().disable() 설정을 적용하였지만 디폴트에서는 켜져있기때문에 csrf토큰이 없어서 403 에러가 발생합니다 (POST, DELETE 요청에 한해서)

따라서 Controller Test에서는 Filter를 불러오지 않고 추 후 Security 테스트를 넣기로 결정하였습니당

https://kth990303.tistory.com/408
https://stackoverflow.com/questions/21749781/why-i-received-an-error-403-with-mockmvc-and-junit
