### PR TITLE
[DPMBE-65] 스웨거 도커 태그 기반 버져닝 표시를 해준다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/swagger/SwaggerConfig.kt
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -37,7 +38,10 @@ import kotlin.reflect.full.findAnnotation
 
 /** Swagger 사용 환경을 위한 설정 파일  */
 @Configuration
-class SwaggerConfig {
+class SwaggerConfig(
+    @Value("\${swagger.version}")
+    private val version: String,
+) {
     private val applicationContext: ApplicationContext? = null
 
     @Bean
@@ -56,7 +60,7 @@ class SwaggerConfig {
         license.url = "https://github.com/depromeet/Whatnow-Api"
         license.name = "Whatnow"
         return Info()
-            .version("v0.0.1")
+            .version("v$version")
             .title("\"Whatnow 서버 API문서\"")
             .description("Whatnow 서버의 API 문서 입니다.")
             .license(license)

--- a/Whatnow-Api/src/main/resources/application.yml
+++ b/Whatnow-Api/src/main/resources/application.yml
@@ -17,6 +17,7 @@ auth:
 swagger:
   user: ${SWAGGER_USER:user}
   password: ${SWAGGER_PASSWORD:password}
+  version: ${WHATNOW_VERSION:0.0.1-SNAPSHOT}
 ---
 spring:
   config:


### PR DESCRIPTION
## 개요
- close #80 

## 작업사항
- 환경변수에 있는 버전 정보를 Swagger Config에서 주입하도록 설정하였습니다.
- deploy repo에서 docker run하기 전 docker image의 버전을 환경변수에서 추가하는 코드 작성하겠습니다

```
WHATNOW_VERSION=$(docker images --format "{{.Tag}}" ${{ secrets.NCP_CONTAINER_REGISTRY}}/whatnow-api)
sed -i "s/WHATNOW_VERSION=.*/WHATNOW_VERSION=${WHATNOW_VERSION}" .env
```
1. docker images 명령어 실행하여 나온 값중에 Tag를 가져와서 `WHATNOW_VERSION` 변수에 저장.
2. sed 명령어를 실행하여 .env 파일에 `WHATNOW_VERSION` 값을 업데이트

## 참고사항
-`WHATNOW_VERSION` 환경변수 추가 하였습니다.
default값 `0.0.1-SNAPSHOT`으로 지정