### PR TITLE
[DPMBE-80] 약속 모음집 상세 조회할 수 있다.(D3_상세 조회)

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.promise.controller
 
 import com.depromeet.whatnow.api.promise.annotation.RequiresMainUser
+import com.depromeet.whatnow.api.promise.dto.PromiseDetailDto
 import com.depromeet.whatnow.api.promise.dto.PromiseDto
 import com.depromeet.whatnow.api.promise.dto.PromiseFindDto
 import com.depromeet.whatnow.api.promise.dto.PromiseRequest
@@ -47,10 +48,17 @@ class PromiseController(
         return promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
     }
 
+    @Deprecated("상태기반 약속 조회", replaceWith = ReplaceWith("findPromiseDetailByStatus"))
     @Operation(summary = "상태기반 약속 조회", description = "예정된(BEFORE), 지난(AFTER) 약속 조회")
     @GetMapping("/promises/users/status/{status}")
     fun findPromiseByStatus(@PathVariable(value = "status") status: PromiseType): List<PromiseFindDto> {
         return promiseReadUseCase.findPromiseWithStatus(status)
+    }
+
+    @Operation(summary = "약속 모음집 상세", description = "D3. 지난(AFTER) 약속 상세 조회 (날짜(월,일), 약속 사진 url, 타임오버 캡쳐, 만난 사람(프로필 tkwls Url,  이름, wait/late 여부, interaction 종륲별 카운트), 하이라이트 기록 최대 3개")
+    @GetMapping("/promises/users/status/{status}/detail")
+    fun findPromiseDetailByStatus(@PathVariable(value = "status") status: PromiseType): List<PromiseDetailDto> {
+        return promiseReadUseCase.findPromiseDetailByStatus(status)
     }
 
     @Operation(summary = "약속(promise) 생성", description = "약속을 생성합니다.")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -48,15 +48,8 @@ class PromiseController(
         return promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
     }
 
-    @Deprecated("상태기반 약속 조회", replaceWith = ReplaceWith("findPromiseDetailByStatus"))
-    @Operation(summary = "상태기반 약속 조회", description = "예정된(BEFORE), 지난(AFTER) 약속 조회")
-    @GetMapping("/promises/users/status/{status}")
-    fun findPromiseByStatus(@PathVariable(value = "status") status: PromiseType): List<PromiseFindDto> {
-        return promiseReadUseCase.findPromiseWithStatus(status)
-    }
-
     @Operation(summary = "약속 모음집 상세", description = "D3. 지난(AFTER) 약속 상세 조회 (날짜(월,일), 약속 사진 url, 타임오버 캡쳐, 만난 사람(프로필 tkwls Url,  이름, wait/late 여부, interaction 종륲별 카운트), 하이라이트 기록 최대 3개")
-    @GetMapping("/promises/users/status/{status}/detail")
+    @GetMapping("/promises/users/status/{status}")
     fun findPromiseDetailByStatus(@PathVariable(value = "status") status: PromiseType): List<PromiseDetailDto> {
         return promiseReadUseCase.findPromiseDetailByStatus(status)
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/LocationCapture.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/LocationCapture.kt
@@ -1,0 +1,14 @@
+package com.depromeet.whatnow.api.promise.dto
+
+import com.depromeet.whatnow.common.vo.CoordinateVo
+
+data class LocationCapture(
+    val userId: Long,
+    val coordinateVo: CoordinateVo,
+) {
+    companion object {
+        fun of(userId: Long, coordinateVo: CoordinateVo): LocationCapture {
+            return LocationCapture(userId, coordinateVo)
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
@@ -1,0 +1,33 @@
+package com.depromeet.whatnow.api.promise.dto
+
+import com.depromeet.whatnow.domains.promise.domain.Promise
+import java.time.LocalDateTime
+
+data class PromiseDetailDto(
+    val title: String,
+    val date: LocalDateTime,
+    // 유저의 마지막 위치 리스트
+    val promiseUsers: List<PromiseUserInfoVo>,
+    // TODO : 약속 기록 사진 기능 추가시 함께 추가할게요.
+    val promiseImageUrls: List<String>?,
+    val timeOverLocations: List<LocationCapture>,
+    // TODO : highlight 기능 추가시 함께 추가할게요. ( 최대 3개 제한 )
+//    val highlights: List<NotificationDto>,
+) {
+    companion object {
+        fun of(
+            promise: Promise,
+            promiseUsers: List<PromiseUserInfoVo>,
+            promiseImageUrls: List<String>,
+            timeOverLocations: List<LocationCapture>,
+        ): PromiseDetailDto {
+            return PromiseDetailDto(
+                title = promise.title,
+                date = promise.endTime,
+                promiseUsers = promiseUsers,
+                promiseImageUrls = promiseImageUrls,
+                timeOverLocations = timeOverLocations,
+            )
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseUserInfoVo.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseUserInfoVo.kt
@@ -1,0 +1,20 @@
+package com.depromeet.whatnow.api.promise.dto
+
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
+import com.depromeet.whatnow.domains.user.domain.User
+
+data class PromiseUserInfoVo(
+    val profileImg: String,
+    val nickname: String,
+    val isDefaultImg: Boolean,
+    val promiseUserType: PromiseUserType,
+    // TODO : Interaction 리스트 ( ex. POOP : 1, MUSIC : 2, ... )
+    // val interactions: List<Interaction>
+) {
+    //    interaction 기능 추가시 함께 추가할게요.
+    companion object {
+        fun of(user: User, promiseUserType: PromiseUserType): PromiseUserInfoVo {
+            return PromiseUserInfoVo(user.profileImg, user.nickname, user.isDefaultImg, promiseUserType)
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -94,24 +94,6 @@ class PromiseReadUseCase(
         return users.mapNotNull { UserInfoVo.from(it) }
     }
 
-    fun findPromiseWithStatus(promiseType: PromiseType): List<PromiseFindDto> {
-        val userId: Long = SecurityUtils.currentUserId
-        val promises = promiseAdaptor.queryPromisesWithStatus(userId, promiseType)
-
-        val promiseUsersByPromiseId = promiseUserAdaptor.findByUniquePromiseIds(promises.map { it.id!! })
-            .groupBy { it.promiseId }
-
-        val promiseFindDtos = mutableListOf<PromiseFindDto>()
-
-//        약속한
-        for (promise in promises) {
-            val participants = promiseUsersByPromiseId[promise.id]?.let { getParticipantUserInfo(it) }
-            promiseFindDtos.add(PromiseFindDto.of(promise, participants!!))
-        }
-
-        return promiseFindDtos
-    }
-
     fun findPromiseDetailByStatus(promiseType: PromiseType): List<PromiseDetailDto> {
         val userId: Long = SecurityUtils.currentUserId
         val promiseUsersByPromiseId = promiseUserAdaptor.findByUserId(userId)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/dto/PromiseUserDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/dto/PromiseUserDto.kt
@@ -6,7 +6,7 @@ import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
 
 data class PromiseUserDto(
     val promiseId: Long,
-    val userId: Long,
+    val mainUserId: Long,
     val userLocation: CoordinateVo?,
     val promiseUserType: PromiseUserType,
 ) {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/ReadUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/ReadUserUseCase.kt
@@ -5,6 +5,7 @@ import com.depromeet.whatnow.common.vo.UserDetailVo
 import com.depromeet.whatnow.common.vo.UserInfoVo
 import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
+import com.depromeet.whatnow.domains.user.domain.User
 
 @UseCase
 class ReadUserUseCase(
@@ -17,5 +18,9 @@ class ReadUserUseCase(
 
     fun findUserById(userId: Long): UserInfoVo {
         return userAdapter.queryUser(userId).toUserInfoVo()
+    }
+
+    fun findUserByIds(userIds: List<Long>): List<User> {
+        return userAdapter.queryUsers(userIds)
     }
 }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
@@ -1,0 +1,114 @@
+package com.depromeet.whatnow.api.promise.usecase
+
+import com.depromeet.whatnow.domains.promise.adaptor.PromiseAdaptor
+import com.depromeet.whatnow.domains.promise.domain.Promise
+import com.depromeet.whatnow.domains.promise.domain.PromiseType
+import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUser
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType.WAIT
+import com.depromeet.whatnow.domains.user.adapter.UserAdapter
+import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
+import com.depromeet.whatnow.domains.user.domain.OauthInfo
+import com.depromeet.whatnow.domains.user.domain.OauthProvider.KAKAO
+import com.depromeet.whatnow.domains.user.domain.User
+import com.depromeet.whatnow.domains.user.repository.UserRepository
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class PromiseReadUseCaseTest {
+
+    @Mock
+    private lateinit var promiseUserAdaptor: PromiseUserAdaptor
+
+    @Mock
+    private lateinit var promiseAdaptor: PromiseAdaptor
+
+    @Mock
+    private lateinit var userAdapter: UserAdapter
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @InjectMocks
+    private lateinit var promiseReadUseCase: PromiseReadUseCase
+
+    @BeforeEach
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        promiseReadUseCase = PromiseReadUseCase(
+            userRepository = userRepository,
+            promiseUserAdaptor = promiseUserAdaptor,
+            promiseAdaptor = promiseAdaptor,
+            userAdapter = userAdapter,
+        )
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        val authentication = UsernamePasswordAuthenticationToken("1", null, setOf(SimpleGrantedAuthority("ROLE_USER")))
+        securityContext.authentication = authentication
+        SecurityContextHolder.setContext(securityContext)
+    }
+
+    @Test
+    fun testFindPromiseDetailByEndTime() {
+        // Given
+        val userId: Long = 1
+        val promiseTime1 = LocalDateTime.now()
+        val promiseTime2 = LocalDateTime.now()
+        val promiseUsers = listOf(
+            PromiseUser(userId = 1, promiseId = 1, promiseUserType = WAIT),
+//            PromiseUser(userId = 2, promiseId = 1, promiseUserType = LATE),
+            PromiseUser(userId = 1, promiseId = 2, promiseUserType = WAIT),
+        )
+        val promises = listOf(
+            Promise(id = 1, title = "Promise 1", endTime = promiseTime1, mainUserId = 1),
+            Promise(id = 2, title = "Promise 2", endTime = promiseTime2, mainUserId = 2L),
+        )
+        val users = listOf(
+            User(
+                oauthInfo = OauthInfo("1234", KAKAO),
+                nickname = "서현",
+                profileImg = "profile1.jpg",
+                isDefaultImg = true,
+                fcmNotification = FcmNotificationVo("1234", true),
+                id = 1,
+            ),
+            User(
+                oauthInfo = OauthInfo("2345", KAKAO),
+                nickname = "찬진",
+                profileImg = "profile2.jpg",
+                isDefaultImg = false,
+                fcmNotification = FcmNotificationVo("2345", true),
+                id = 2,
+            ),
+        )
+
+        Mockito.`when`(promiseUserAdaptor.findByUserId(userId)).thenReturn(promiseUsers)
+        Mockito.`when`(promiseAdaptor.queryPromises(listOf(1, 2))).thenReturn(promises)
+        Mockito.`when`(userAdapter.queryUsers(listOf(1))).thenReturn(users)
+
+        // When
+        val result = promiseReadUseCase.findPromiseDetailByStatus(PromiseType.BEFORE)
+
+        // Then
+        Assertions.assertEquals(2, result.size)
+
+        Assertions.assertEquals("Promise 1", result[0].title)
+        Assertions.assertEquals(promiseTime1, result[0].date)
+        Assertions.assertEquals(1, result[0].promiseUsers.size)
+
+        Assertions.assertEquals("Promise 2", result[1].title)
+        Assertions.assertEquals(promiseTime2, result[1].date)
+        Assertions.assertEquals(1, result[1].promiseUsers.size)
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserReadUseCaseTest.kt
@@ -57,23 +57,4 @@ class PromiseUserReadUseCaseTest {
             .map { PromiseUserDto.from(it) }
         assertEquals(expected, result)
     }
-
-    @Test
-    fun `PromiseUserType에_따라_필터링하여_조회할_수_있다`() {
-        val userId = 1L
-        val status = "READY"
-        val promiseUserList = listOf(
-            PromiseUser(1L, 1L, CoordinateVo(100.4, 1.2), PromiseUserType.READY),
-            PromiseUser(2L, 2L, CoordinateVo(123.4, 132.6), PromiseUserType.READY),
-            PromiseUser(3L, 1L, CoordinateVo(123.445, 6789.612), PromiseUserType.WAIT),
-        )
-        `when`(promiseUserDomainService.findByUserId(userId)).thenReturn(promiseUserList)
-
-        val result = promiseUserReadUseCase.findByUserIdWithStatus(userId, status)
-
-        val expected = promiseUserList
-            .filter { it.promiseUserType == PromiseUserType.valueOf(status) }
-            .map { PromiseUserDto.from(it) }
-        assertEquals(expected, result)
-    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/adapter/UserAdapter.kt
@@ -16,6 +16,10 @@ class UserAdapter(
         return userRepository.findByIdOrNull(userId) ?: run { throw UserNotFoundException.EXCEPTION }
     }
 
+    fun queryUsers(userIds: List<Long>): List<User> {
+        return userRepository.findAllById(userIds)
+    }
+
     fun queryByOauthInfo(oauthInfo: OauthInfo): User {
         return userRepository.findByOauthInfo(oauthInfo) ?: run { throw UserNotFoundException.EXCEPTION }
     }


### PR DESCRIPTION
## 개요
- close #104 

## 작업사항
- 약속 상태 (BEFORE, AFTER) 에 따라서 약속 상세를 조회할 수 있다.
- 차 후에 interaction, imageUrl List 를 DetailDto 에 추가할 예정입니다. 
```
data class PromiseDetailDto(
    val title: String,
    val date: LocalDateTime,
    // 유저의 마지막 위치 리스트
    val promiseUsers: List<PromiseUserInfoVo>,
    // TODO : 약속 기록 사진 기능 추가시 함께 추가할게요.
    val promiseImageUrls: List<String>?,
    val timeOverLocations: List<LocationCapture>,
    // TODO : highlight 기능 추가시 함께 추가할게요. ( 최대 3개 제한 )
//    val highlights: List<NotificationDto>,
) {
```

## 변경로직
- 기존 status 요청 deprecated