### PR TITLE
[DPMBE-73] 인터렉션 init, 비지니스 로직을 구현한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
@@ -1,5 +1,7 @@
 package com.depromeet.whatnow.api.interaction.controller
 
+import com.depromeet.whatnow.api.interaction.dto.InteractionResponse
+import com.depromeet.whatnow.api.interaction.usecase.InteractionReadUseCase
 import com.depromeet.whatnow.api.interaction.usecase.InteractionSendUseCase
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import io.swagger.v3.oas.annotations.Operation
@@ -7,6 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -18,6 +21,8 @@ import org.springframework.web.bind.annotation.RestController
 @SecurityRequirement(name = "access-token")
 class InteractionController(
     val interactionSendUseCase: InteractionSendUseCase,
+    val interactionReadUseCase: InteractionReadUseCase,
+//    val interactionReadDetailUseCase: InteractionReadDetailUseCase,
 ) {
     @PostMapping("/promises/{promiseId}/interactions/{interactionType}/target/{targetUserId}")
     @Operation(summary = "인터렉션을 발송합니다.")
@@ -28,5 +33,13 @@ class InteractionController(
     ): ResponseEntity<Unit> {
         interactionSendUseCase.execute(promiseId, interactionType, targetUserId)
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(Unit)
+    }
+
+    @GetMapping("/users/me/promises/{promiseId}/interactions")
+    @Operation(summary = "자신의 인터렉션 정보를 가져옵니다.")
+    fun getMyInteraction(
+        @PathVariable promiseId: Long,
+    ): InteractionResponse {
+        return interactionReadUseCase.findMyInteraction(promiseId)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
@@ -1,0 +1,32 @@
+package com.depromeet.whatnow.api.interaction.controller
+
+import com.depromeet.whatnow.api.interaction.usecase.InteractionSendUseCase
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Tag(name = "7. [인터렉션]")
+@RequestMapping("/v1")
+@SecurityRequirement(name = "access-token")
+class InteractionController(
+    val interactionSendUseCase: InteractionSendUseCase,
+) {
+    @PostMapping("/promises/{promiseId}/interactions/{interactionType}/target/{targetUserId}")
+    @Operation(summary = "인터렉션을 발송합니다.")
+    fun sendInteraction(
+        @PathVariable promiseId: Long,
+        @PathVariable interactionType: InteractionType,
+        @PathVariable targetUserId: Long,
+    ): ResponseEntity<Unit> {
+        interactionSendUseCase.execute(promiseId, interactionType, targetUserId)
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(Unit)
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
@@ -37,7 +37,7 @@ class InteractionController(
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(Unit)
     }
 
-    @GetMapping("/users/me/promises/{promiseId}/interactions")
+    @GetMapping("/promises/{promiseId}/interactions")
     @Operation(summary = "자신의 인터렉션 정보를 가져옵니다.")
     fun getMyInteraction(
         @PathVariable promiseId: Long,
@@ -45,7 +45,7 @@ class InteractionController(
         return interactionReadUseCase.findMyInteraction(promiseId)
     }
 
-    @GetMapping("/users/me/promises/{promiseId}/interactions/{interactionType}")
+    @GetMapping("/promises/{promiseId}/interactions/{interactionType}")
     @Operation(summary = "자신의 인터렉션 상세 정보를 가져옵니다.")
     fun getMyInteractionDetail(
         @PathVariable promiseId: Long,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/controller/InteractionController.kt
@@ -1,6 +1,8 @@
 package com.depromeet.whatnow.api.interaction.controller
 
+import com.depromeet.whatnow.api.interaction.dto.InteractionDetailResponse
 import com.depromeet.whatnow.api.interaction.dto.InteractionResponse
+import com.depromeet.whatnow.api.interaction.usecase.InteractionReadDetailUseCase
 import com.depromeet.whatnow.api.interaction.usecase.InteractionReadUseCase
 import com.depromeet.whatnow.api.interaction.usecase.InteractionSendUseCase
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
@@ -22,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class InteractionController(
     val interactionSendUseCase: InteractionSendUseCase,
     val interactionReadUseCase: InteractionReadUseCase,
-//    val interactionReadDetailUseCase: InteractionReadDetailUseCase,
+    val interactionReadDetailUseCase: InteractionReadDetailUseCase,
 ) {
     @PostMapping("/promises/{promiseId}/interactions/{interactionType}/target/{targetUserId}")
     @Operation(summary = "인터렉션을 발송합니다.")
@@ -41,5 +43,14 @@ class InteractionController(
         @PathVariable promiseId: Long,
     ): InteractionResponse {
         return interactionReadUseCase.findMyInteraction(promiseId)
+    }
+
+    @GetMapping("/users/me/promises/{promiseId}/interactions/{interactionType}")
+    @Operation(summary = "자신의 인터렉션 상세 정보를 가져옵니다.")
+    fun getMyInteractionDetail(
+        @PathVariable promiseId: Long,
+        @PathVariable interactionType: InteractionType,
+    ): InteractionDetailResponse {
+        return interactionReadDetailUseCase.findMyInteractionDetail(promiseId, interactionType)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
@@ -8,13 +8,4 @@ data class InteractionDetailDto(
     val senderUser: UserInfoVo,
     val count: Long,
     val interactionType: InteractionType,
-) {
-    companion object {
-        fun from(it: InteractionHistory) {
-            TODO("Not yet implemented")
-        }
-//        fun from(interaction: Interaction): InteractionDetailDto {
-//            return InteractionDetailDto(interaction.promiseId, interaction.userId, interaction.interactionType, interaction.count)
-//        }
-    }
-}
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
@@ -2,7 +2,6 @@ package com.depromeet.whatnow.api.interaction.dto
 
 import com.depromeet.whatnow.common.vo.UserInfoVo
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
-import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
 
 data class InteractionDetailDto(
     val senderUser: UserInfoVo,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailDto.kt
@@ -1,0 +1,20 @@
+package com.depromeet.whatnow.api.interaction.dto
+
+import com.depromeet.whatnow.common.vo.UserInfoVo
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
+
+data class InteractionDetailDto(
+    val senderUser: UserInfoVo,
+    val count: Long,
+    val interactionType: InteractionType,
+) {
+    companion object {
+        fun from(it: InteractionHistory) {
+            TODO("Not yet implemented")
+        }
+//        fun from(interaction: Interaction): InteractionDetailDto {
+//            return InteractionDetailDto(interaction.promiseId, interaction.userId, interaction.interactionType, interaction.count)
+//        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDetailResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.interaction.dto
+
+data class InteractionDetailResponse(
+    val interactions: List<InteractionDetailDto>,
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionDto.kt
@@ -1,0 +1,17 @@
+package com.depromeet.whatnow.api.interaction.dto
+
+import com.depromeet.whatnow.domains.interaction.domain.Interaction
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+
+data class InteractionDto(
+    val promiseId: Long,
+    val userId: Long,
+    val interactionType: InteractionType,
+    val count: Long,
+) {
+    companion object {
+        fun from(interaction: Interaction): InteractionDto {
+            return InteractionDto(interaction.promiseId, interaction.userId, interaction.interactionType, interaction.count)
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/dto/InteractionResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.api.interaction.dto
+
+data class InteractionResponse(
+    val interactionDtoList: List<InteractionDto>,
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionReadDetailUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionReadDetailUseCase.kt
@@ -1,0 +1,29 @@
+package com.depromeet.whatnow.api.interaction.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.interaction.dto.InteractionDetailDto
+import com.depromeet.whatnow.api.interaction.dto.InteractionDetailResponse
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interactionhistory.service.InteractionHistoryDomainService
+import com.depromeet.whatnow.domains.user.adapter.UserAdapter
+
+@UseCase
+class InteractionReadDetailUseCase(
+    val interactionHistoryDomainService: InteractionHistoryDomainService,
+    val userAdapter: UserAdapter,
+) {
+    fun findMyInteractionDetail(promiseId: Long, interactionType: InteractionType): InteractionDetailResponse {
+        val userId = SecurityUtils.currentUserId
+        return InteractionDetailResponse(
+            interactionHistoryDomainService.queryAllByInteractionType(userId, promiseId, interactionType)
+                .groupBy { it.targetUserId }.map { (targetUserId, interactionHistories) ->
+                    InteractionDetailDto(
+                        userAdapter.queryUser(targetUserId).toUserInfoVo(),
+                        interactionHistories.size.toLong(),
+                        interactionType,
+                    )
+                }.sortedByDescending { it.count },
+        )
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionReadUseCase.kt
@@ -1,0 +1,20 @@
+package com.depromeet.whatnow.api.interaction.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.interaction.dto.InteractionDto
+import com.depromeet.whatnow.api.interaction.dto.InteractionResponse
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.interaction.service.InteractionDomainService
+
+@UseCase
+class InteractionReadUseCase(
+    val interactionDomainService: InteractionDomainService,
+) {
+
+    fun findMyInteraction(promiseId: Long): InteractionResponse {
+        val userId: Long = SecurityUtils.currentUserId
+        return InteractionResponse(
+            interactionDomainService.queryAllInteraction(promiseId, userId).map { InteractionDto.from(it) },
+        )
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionSendUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/interaction/usecase/InteractionSendUseCase.kt
@@ -1,0 +1,16 @@
+package com.depromeet.whatnow.api.interaction.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interactionhistory.service.InteractionHistoryDomainService
+
+@UseCase
+class InteractionSendUseCase(
+    val interactionHistoryDomainService: InteractionHistoryDomainService,
+) {
+    fun execute(promiseId: Long, interactionType: InteractionType, targetUserId: Long) {
+        val userId = SecurityUtils.currentUserId
+        interactionHistoryDomainService.sendInteraction(promiseId, interactionType, userId, targetUserId)
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseprogress/usecase/ProgressHistoryReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseprogress/usecase/ProgressHistoryReadUseCase.kt
@@ -2,6 +2,7 @@ package com.depromeet.whatnow.api.promiseprogress.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
 import com.depromeet.whatnow.api.promiseprogress.dto.response.UserProgressResponse
+import com.depromeet.whatnow.common.aop.verify.CheckUserParticipation
 import com.depromeet.whatnow.domains.progresshistory.adapter.ProgressHistoryAdapter
 import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
@@ -12,10 +13,8 @@ class ProgressHistoryReadUseCase(
     val promiseUserAdapter: PromiseUserAdaptor,
     val userAdapter: UserAdapter,
 ) {
+    @CheckUserParticipation
     fun execute(promiseId: Long, userId: Long): UserProgressResponse {
-        // 해당 유저가 해당 약속에 있는지 검증을... 함 해야햐긴함!
-        // 이부분은 나중에 깔쌈하게 누가 aop로 만들면 참 좋을듯
-        promiseUserAdapter.findByPromiseIdAndUserId(promiseId, userId)
         val history = progressHistoryAdapter.findByPromiseIdAndUserId(promiseId, userId)
         return UserProgressResponse(userAdapter.queryUser(userId).toUserInfoVo(), history.currentPromiseProgress, history.prePromiseProgress)
     }

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/GlobalErrorCode.kt
@@ -82,6 +82,22 @@ enum class GlobalErrorCode(val status: Int, val code: String, val reason: String
     OTHER_SERVER_INTERNAL_SERVER_ERROR(INTERNAL_SERVER, "OTHER_SERVER_500_1", "다른 서버에서 알 수 없는 서버 오류가 발생했습니다."),
 
     SECURITY_CONTEXT_NOT_FOUND(INTERNAL_SERVER, "GLOBAL_500_2", "security context not found"),
+
+    @ExplainError("해당 약속에 유저가 참여하지 않을때 발생하는 오류입니다.")
+    USER_NOT_PARTICIPATE(BAD_REQUEST, "GLOBAL_400_2", "해당 약속에 유저가 참여하지 않습니다."),
+
+    @ExplainError("userId를 Long으로 변환시 발생하는 오류입니다.")
+    USER_ID_NOT_LONG(INTERNAL_SERVER, "GLOBAL_500_5", "userId를 Long으로 변환시 발생하는 오류입니다."),
+
+    @ExplainError("promiseId를 Long으로 변환시 발생하는 오류입니다.")
+    PROMISE_ID_NOT_LONG(INTERNAL_SERVER, "GLOBAL_500_6", "promiseId를 Long으로 변환시 발생하는 오류입니다."),
+
+    @ExplainError("userId가 파라미터에 없을 때 발생하는 오류입니다.")
+    USER_ID_PARAMETER_NOT_FOUND(BAD_REQUEST, "GLOBAL_400_3", "userId가 파라미터에 없습니다."),
+
+    @ExplainError("promiseId가 파라미터에 없을 때 발생하는 오류입니다.")
+    PROMISE_ID_PARAMETER_NOT_FOUND(BAD_REQUEST, "GLOBAL_400_4", "promiseId가 파라미터에 없습니다."),
+
     ;
 
     override val errorReason: ErrorReason

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotParticipatedInPromiseException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotParticipatedInPromiseException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class NotParticipatedInPromiseException: WhatnowCodeException(
+    GlobalErrorCode.USER_NOT_PARTICIPATE,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = NotParticipatedInPromiseException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotParticipatedInPromiseException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/NotParticipatedInPromiseException.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.exception.custom
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
-class NotParticipatedInPromiseException: WhatnowCodeException(
+class NotParticipatedInPromiseException : WhatnowCodeException(
     GlobalErrorCode.USER_NOT_PARTICIPATE,
 ) {
     companion object {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdConversionException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdConversionException.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.exception.custom
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
-class PromiseIdConversionException: WhatnowCodeException(
+class PromiseIdConversionException : WhatnowCodeException(
     GlobalErrorCode.PROMISE_ID_NOT_LONG,
 ) {
     companion object {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdConversionException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdConversionException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class PromiseIdConversionException: WhatnowCodeException(
+    GlobalErrorCode.PROMISE_ID_NOT_LONG,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = PromiseIdConversionException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdParameterNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdParameterNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class PromiseIdParameterNotFoundException: WhatnowCodeException(
+    GlobalErrorCode.PROMISE_ID_PARAMETER_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = PromiseIdParameterNotFoundException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdParameterNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/PromiseIdParameterNotFoundException.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.exception.custom
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
-class PromiseIdParameterNotFoundException: WhatnowCodeException(
+class PromiseIdParameterNotFoundException : WhatnowCodeException(
     GlobalErrorCode.PROMISE_ID_PARAMETER_NOT_FOUND,
 ) {
     companion object {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdConversionException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdConversionException.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.exception.custom
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
-class UserIdConversionException: WhatnowCodeException(
+class UserIdConversionException : WhatnowCodeException(
     GlobalErrorCode.USER_ID_NOT_LONG,
 ) {
     companion object {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdConversionException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdConversionException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class UserIdConversionException: WhatnowCodeException(
+    GlobalErrorCode.USER_ID_NOT_LONG,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = UserIdConversionException()
+    }
+}

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdParameterNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdParameterNotFoundException.kt
@@ -3,7 +3,7 @@ package com.depromeet.whatnow.exception.custom
 import com.depromeet.whatnow.exception.GlobalErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
-class UserIdParameterNotFoundException: WhatnowCodeException(
+class UserIdParameterNotFoundException : WhatnowCodeException(
     GlobalErrorCode.USER_ID_PARAMETER_NOT_FOUND,
 ) {
     companion object {

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdParameterNotFoundException.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/exception/custom/UserIdParameterNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.exception.custom
+
+import com.depromeet.whatnow.exception.GlobalErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class UserIdParameterNotFoundException: WhatnowCodeException(
+    GlobalErrorCode.USER_ID_PARAMETER_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = UserIdParameterNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipation.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipation.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.common.aop.verify
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CheckUserParticipation

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
@@ -37,17 +37,16 @@ class CheckUserParticipationAop(
     private fun findUserIdArg(methodParameterNames: Array<String>, args: Array<Any>): Long {
         for (i in methodParameterNames.indices) {
             if ((methodParameterNames[i] == "userId")) {
-                val arg = args[i]
-                if (arg is Long) {
-                    return arg
-                } else if (arg is String) {
-                    try {
-                        return arg.toLong()
-                    } catch (e: NumberFormatException) {
-                        throw UserIdConversionException.EXCEPTION
+                when (val arg = args[i]) {
+                    is Long -> return arg
+                    is String -> {
+                        try {
+                            return arg.toLong()
+                        } catch (e: NumberFormatException) {
+                            throw UserIdConversionException.EXCEPTION
+                        }
                     }
-                } else {
-                    UserIdParameterNotFoundException.EXCEPTION
+                    else -> UserIdParameterNotFoundException.EXCEPTION
                 }
             }
         }
@@ -57,17 +56,16 @@ class CheckUserParticipationAop(
     private fun findPromiseIdArg(methodParameterNames: Array<String>, args: Array<Any>): Long {
         for (i in methodParameterNames.indices) {
             if ((methodParameterNames[i] == "promiseId")) {
-                val arg = args[i]
-                if (arg is Long) {
-                    return arg
-                } else if (arg is String) {
-                    try {
-                        return arg.toLong()
-                    } catch (e: NumberFormatException) {
-                        throw PromiseIdConversionException.EXCEPTION
+                when (val arg = args[i]) {
+                    is Long -> return arg
+                    is String -> {
+                        try {
+                            return arg.toLong()
+                        } catch (e: NumberFormatException) {
+                            throw PromiseIdConversionException.EXCEPTION
+                        }
                     }
-                } else {
-                    PromiseIdParameterNotFoundException.EXCEPTION
+                    else -> PromiseIdParameterNotFoundException.EXCEPTION
                 }
             }
         }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
@@ -1,0 +1,85 @@
+package com.depromeet.whatnow.common.aop.verify
+
+import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
+import com.depromeet.whatnow.domains.promiseuser.exception.PromiseUserNotFoundException
+import com.depromeet.whatnow.exception.custom.NotParticipatedInPromiseException
+import com.depromeet.whatnow.exception.custom.PromiseIdConversionException
+import com.depromeet.whatnow.exception.custom.PromiseIdParameterNotFoundException
+import com.depromeet.whatnow.exception.custom.UserIdConversionException
+import com.depromeet.whatnow.exception.custom.UserIdParameterNotFoundException
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Component
+import java.lang.NumberFormatException
+
+@Aspect
+@Component
+@ConditionalOnExpression("\${ableCheckUserParticipation:true}")
+class CheckUserParticipationAop(
+    val promiseUserAdaptor: PromiseUserAdaptor
+) {
+    @Around("@annotation(com.depromeet.whatnow.common.aop.verify.CheckUserParticipation)")
+    fun verify(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val args = joinPoint.args
+        val userId = findUserIdArg(signature.parameterNames, args)
+        val promiseId = findPromiseIdArg(signature.parameterNames, args)
+
+        if (userIdInPromise(userId, promiseId)) {
+            return joinPoint.proceed()
+        }
+        throw NotParticipatedInPromiseException.EXCEPTION
+    }
+
+    private fun findUserIdArg(methodParameterNames: Array<String>,args: Array<Any>): Long {
+        for (i in methodParameterNames.indices) {
+            if ((methodParameterNames[i] == "userId")) {
+                val arg = args[i]
+                if (arg is Long) {
+                    return arg
+                } else if (arg is String) {
+                    try {
+                        return arg.toLong()
+                    } catch (e: NumberFormatException) {
+                        throw UserIdConversionException.EXCEPTION
+                    }
+                } else {
+                    UserIdParameterNotFoundException.EXCEPTION
+                }
+            }
+        }
+        throw UserIdParameterNotFoundException.EXCEPTION
+    }
+
+    private fun findPromiseIdArg(methodParameterNames: Array<String>,args: Array<Any>): Long {
+        for (i in methodParameterNames.indices) {
+            if ((methodParameterNames[i] == "promiseId")) {
+                val arg = args[i]
+                if (arg is Long) {
+                    return arg
+                } else if (arg is String) {
+                    try {
+                        return arg.toLong()
+                    } catch (e: NumberFormatException) {
+                        throw PromiseIdConversionException.EXCEPTION
+                    }
+                } else {
+                    PromiseIdParameterNotFoundException.EXCEPTION
+                }
+            }
+        }
+        throw PromiseIdParameterNotFoundException.EXCEPTION
+    }
+
+    private fun userIdInPromise(userId: Long, promiseId: Long): Boolean {
+        return try {
+            promiseUserAdaptor.findByPromiseIdAndUserId(promiseId, userId)
+            true
+        } catch (e: PromiseUserNotFoundException) {
+            false
+        }
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/CheckUserParticipationAop.kt
@@ -19,7 +19,7 @@ import java.lang.NumberFormatException
 @Component
 @ConditionalOnExpression("\${ableCheckUserParticipation:true}")
 class CheckUserParticipationAop(
-    val promiseUserAdaptor: PromiseUserAdaptor
+    val promiseUserAdaptor: PromiseUserAdaptor,
 ) {
     @Around("@annotation(com.depromeet.whatnow.common.aop.verify.CheckUserParticipation)")
     fun verify(joinPoint: ProceedingJoinPoint): Any? {
@@ -34,7 +34,7 @@ class CheckUserParticipationAop(
         throw NotParticipatedInPromiseException.EXCEPTION
     }
 
-    private fun findUserIdArg(methodParameterNames: Array<String>,args: Array<Any>): Long {
+    private fun findUserIdArg(methodParameterNames: Array<String>, args: Array<Any>): Long {
         for (i in methodParameterNames.indices) {
             if ((methodParameterNames[i] == "userId")) {
                 val arg = args[i]
@@ -54,7 +54,7 @@ class CheckUserParticipationAop(
         throw UserIdParameterNotFoundException.EXCEPTION
     }
 
-    private fun findPromiseIdArg(methodParameterNames: Array<String>,args: Array<Any>): Long {
+    private fun findPromiseIdArg(methodParameterNames: Array<String>, args: Array<Any>): Long {
         for (i in methodParameterNames.indices) {
             if ((methodParameterNames[i] == "promiseId")) {
                 val arg = args[i]

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/adapter/InteractionAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/adapter/InteractionAdapter.kt
@@ -16,4 +16,8 @@ class InteractionAdapter(
     fun queryInteraction(promiseId: Long, userId: Long, interactionType: InteractionType): Interaction {
         return interactionRepository.findByPromiseIdAndUserIdAndInteractionType(promiseId, userId, interactionType)
     }
+
+    fun queryAllInteraction(promiseId: Long, userId: Long): List<Interaction> {
+        return interactionRepository.findAllByPromiseIdAndUserId(promiseId, userId)
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/adapter/InteractionAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/adapter/InteractionAdapter.kt
@@ -1,0 +1,19 @@
+package com.depromeet.whatnow.domains.interaction.adapter
+
+import com.depromeet.whatnow.annotation.Adapter
+import com.depromeet.whatnow.domains.interaction.domain.Interaction
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interaction.repository.InteractionRepository
+
+@Adapter
+class InteractionAdapter(
+    val interactionRepository: InteractionRepository,
+) {
+    fun save(interaction: Interaction) {
+        interactionRepository.save(interaction)
+    }
+
+    fun queryInteraction(promiseId: Long, userId: Long, interactionType: InteractionType): Interaction {
+        return interactionRepository.findByPromiseIdAndUserIdAndInteractionType(promiseId, userId, interactionType)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/domain/Interaction.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/domain/Interaction.kt
@@ -16,12 +16,24 @@ class Interaction(
     @Enumerated(EnumType.STRING)
     var interactionType: InteractionType,
 
-    var message: String,
+    var userId: Long,
 
-    var img: String,
+    var promiseId: Long,
+
+    var count: Long,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "interaction_id")
     val id: Long? = null,
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    fun increment() {
+        count += 1
+    }
+
+    companion object {
+        fun of(promiseId: Long, userId: Long, interactionType: InteractionType): Interaction {
+            return Interaction(interactionType, userId, promiseId, 0)
+        }
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/InteractionHistoryRegisterHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/InteractionHistoryRegisterHandler.kt
@@ -5,6 +5,7 @@ import com.depromeet.whatnow.domains.interaction.service.InteractionDomainServic
 import com.depromeet.whatnow.domains.interactionhistory.event.InteractionHistoryRegisterEvent
 import mu.KLogger
 import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -14,6 +15,7 @@ class InteractionHistoryRegisterHandler(
 ) {
     val logger: KLogger = KotlinLogging.logger {}
 
+    @Async
     @TransactionalEventListener(classes = [InteractionHistoryRegisterEvent::class], phase = TransactionPhase.AFTER_COMMIT)
     fun handleInteractionHistoryRegisterEvent(event: InteractionHistoryRegisterEvent) {
         logger.info { "handleInteractionHistoryRegisterEvent 이벤트 약속아이디 {${event.promiseId} , 유저아이디: ${event.userId} , 상대방 유저아이디: ${event.targetUserId} , 인터렉션타입: ${event.interactionType}" }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/InteractionHistoryRegisterHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/InteractionHistoryRegisterHandler.kt
@@ -1,0 +1,22 @@
+package com.depromeet.whatnow.domains.interaction.handler
+
+import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.domains.interaction.service.InteractionDomainService
+import com.depromeet.whatnow.domains.interactionhistory.event.InteractionHistoryRegisterEvent
+import mu.KLogger
+import mu.KotlinLogging
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Handler
+class InteractionHistoryRegisterHandler(
+    val interactionDomainService: InteractionDomainService,
+) {
+    val logger: KLogger = KotlinLogging.logger {}
+
+    @TransactionalEventListener(classes = [InteractionHistoryRegisterEvent::class], phase = TransactionPhase.AFTER_COMMIT)
+    fun handleInteractionHistoryRegisterEvent(event: InteractionHistoryRegisterEvent) {
+        logger.info { "handleInteractionHistoryRegisterEvent 이벤트 약속아이디 {${event.promiseId} , 유저아이디: ${event.userId} , 상대방 유저아이디: ${event.targetUserId} , 인터렉션타입: ${event.interactionType}" }
+        interactionDomainService.increment(event.promiseId, event.userId, event.interactionType)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/PromiseUserRegisterInteractionInitHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/handler/PromiseUserRegisterInteractionInitHandler.kt
@@ -1,0 +1,22 @@
+package com.depromeet.whatnow.domains.interaction.handler
+
+import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.domains.interaction.service.InteractionDomainService
+import com.depromeet.whatnow.events.domainEvent.PromiseUserRegisterEvent
+import mu.KLogger
+import mu.KotlinLogging
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Handler
+class PromiseUserRegisterInteractionInitHandler(
+    val interactionDomainService: InteractionDomainService,
+) {
+    val logger: KLogger = KotlinLogging.logger {}
+
+    @TransactionalEventListener(classes = [PromiseUserRegisterEvent::class], phase = TransactionPhase.AFTER_COMMIT)
+    fun handlePromiseUserRegisterEvent(event: PromiseUserRegisterEvent) {
+        logger.info { "PromiseUserRegisterInteractionInitHandler 이벤트 수신 약속아이디: ${event.promiseId} , 유저아이디: ${event.userId}" }
+        interactionDomainService.initInteraction(event.promiseId, event.userId)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/repository/InteractionRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/repository/InteractionRepository.kt
@@ -1,0 +1,13 @@
+package com.depromeet.whatnow.domains.interaction.repository
+
+import com.depromeet.whatnow.domains.interaction.domain.Interaction
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InteractionRepository : JpaRepository<Interaction, Long> {
+    fun findByPromiseIdAndUserIdAndInteractionType(
+        promiseId: Long,
+        userId: Long,
+        interactionType: InteractionType,
+    ): Interaction
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/repository/InteractionRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/repository/InteractionRepository.kt
@@ -10,4 +10,6 @@ interface InteractionRepository : JpaRepository<Interaction, Long> {
         userId: Long,
         interactionType: InteractionType,
     ): Interaction
+
+    fun findAllByPromiseIdAndUserId(promiseId: Long, userId: Long): List<Interaction>
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class InteractionDomainService(
     val interactionAdapter: InteractionAdapter,
 ) {
+    @Transactional
     fun initInteraction(promiseId: Long, userId: Long) {
         InteractionType.values().forEach { interactionType ->
             interactionAdapter.save(Interaction.of(promiseId, userId, interactionType))
@@ -30,6 +31,7 @@ class InteractionDomainService(
     }
 
     @CheckUserParticipation
+    @Transactional(readOnly = true)
     fun queryAllInteraction(promiseId: Long, userId: Long): List<Interaction> {
         return interactionAdapter.queryAllInteraction(promiseId, userId)
     }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -23,6 +23,7 @@ class InteractionDomainService(
         identifier = "userId",
     )
     @Transactional
+    @CheckUserParticipation
     fun increment(promiseId: Long, userId: Long, interactionType: InteractionType) {
         val interaction = interactionAdapter.queryInteraction(promiseId, userId, interactionType)
         interaction.increment()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -28,6 +28,7 @@ class InteractionDomainService(
         interaction.increment()
     }
 
+    @CheckUserParticipation
     fun queryAllInteraction(promiseId: Long, userId: Long): List<Interaction> {
         return interactionAdapter.queryAllInteraction(promiseId, userId)
     }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.interaction.service
 
 import com.depromeet.whatnow.common.aop.lock.RedissonLock
+import com.depromeet.whatnow.common.aop.verify.CheckUserParticipation
 import com.depromeet.whatnow.domains.interaction.adapter.InteractionAdapter
 import com.depromeet.whatnow.domains.interaction.domain.Interaction
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
@@ -25,5 +26,9 @@ class InteractionDomainService(
     fun increment(promiseId: Long, userId: Long, interactionType: InteractionType) {
         val interaction = interactionAdapter.queryInteraction(promiseId, userId, interactionType)
         interaction.increment()
+    }
+
+    fun queryAllInteraction(promiseId: Long, userId: Long): List<Interaction> {
+        return interactionAdapter.queryAllInteraction(promiseId, userId)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -23,7 +23,6 @@ class InteractionDomainService(
         lockName = "인터렉션",
         identifier = "userId",
     )
-    @Transactional
     @CheckUserParticipation
     fun increment(promiseId: Long, userId: Long, interactionType: InteractionType) {
         val interaction = interactionAdapter.queryInteraction(promiseId, userId, interactionType)

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainService.kt
@@ -1,0 +1,29 @@
+package com.depromeet.whatnow.domains.interaction.service
+
+import com.depromeet.whatnow.common.aop.lock.RedissonLock
+import com.depromeet.whatnow.domains.interaction.adapter.InteractionAdapter
+import com.depromeet.whatnow.domains.interaction.domain.Interaction
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InteractionDomainService(
+    val interactionAdapter: InteractionAdapter,
+) {
+    fun initInteraction(promiseId: Long, userId: Long) {
+        InteractionType.values().forEach { interactionType ->
+            interactionAdapter.save(Interaction.of(promiseId, userId, interactionType))
+        }
+    }
+
+    @RedissonLock(
+        lockName = "인터렉션",
+        identifier = "userId",
+    )
+    @Transactional
+    fun increment(promiseId: Long, userId: Long, interactionType: InteractionType) {
+        val interaction = interactionAdapter.queryInteraction(promiseId, userId, interactionType)
+        interaction.increment()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/adapter/InteractionHistoryAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/adapter/InteractionHistoryAdapter.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.interactionhistory.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
 import com.depromeet.whatnow.domains.interactionhistory.repository.InteractionHistoryRepository
 
@@ -10,5 +11,9 @@ class InteractionHistoryAdapter(
 ) {
     fun save(interactionHistory: InteractionHistory) {
         interactionHistoryRepository.save(interactionHistory)
+    }
+
+    fun queryAllByInteractionType(userId: Long, promiseId: Long, interactionType: InteractionType): List<InteractionHistory> {
+        return interactionHistoryRepository.findAllByUserIdAndPromiseIdAndInteractionType(userId, promiseId, interactionType)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/adapter/InteractionHistoryAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/adapter/InteractionHistoryAdapter.kt
@@ -1,0 +1,14 @@
+package com.depromeet.whatnow.domains.interactionhistory.adapter
+
+import com.depromeet.whatnow.annotation.Adapter
+import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
+import com.depromeet.whatnow.domains.interactionhistory.repository.InteractionHistoryRepository
+
+@Adapter
+class InteractionHistoryAdapter(
+    val interactionHistoryRepository: InteractionHistoryRepository,
+) {
+    fun save(interactionHistory: InteractionHistory) {
+        interactionHistoryRepository.save(interactionHistory)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/domain/InteractionHistory.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/domain/InteractionHistory.kt
@@ -1,0 +1,46 @@
+package com.depromeet.whatnow.domains.interactionhistory.domain
+
+import com.depromeet.whatnow.common.BaseTimeEntity
+import com.depromeet.whatnow.common.aop.event.Events
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interactionhistory.event.InteractionHistoryRegisterEvent
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.PostPersist
+import javax.persistence.Table
+
+@Entity
+@Table(name = "tbl_interaction_history")
+class InteractionHistory(
+    var promiseId: Long,
+
+    var interactionType: InteractionType,
+
+    var userId: Long,
+
+    var targetUserId: Long,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interaction_history_id")
+    val id: Long? = null,
+) : BaseTimeEntity() {
+    @PostPersist
+    fun createInteractionHistoryEvent() {
+        Events.raise(InteractionHistoryRegisterEvent(this.promiseId, this.interactionType, this.userId, this.targetUserId))
+    }
+
+    companion object {
+        fun of(
+            promiseId: Long,
+            interactionType: InteractionType,
+            userId: Long,
+            targetUserId: Long,
+        ): InteractionHistory {
+            return InteractionHistory(promiseId, interactionType, userId, targetUserId)
+        }
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/event/InteractionHistoryRegisterEvent.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/event/InteractionHistoryRegisterEvent.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.interactionhistory.event
+
+import com.depromeet.whatnow.common.aop.event.DomainEvent
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+
+class InteractionHistoryRegisterEvent(
+    val promiseId: Long,
+    val interactionType: InteractionType,
+    val userId: Long,
+    val targetUserId: Long,
+) : DomainEvent()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/repository/InteractionHistoryRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/repository/InteractionHistoryRepository.kt
@@ -1,0 +1,6 @@
+package com.depromeet.whatnow.domains.interactionhistory.repository
+
+import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InteractionHistoryRepository : JpaRepository<InteractionHistory, Long>

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/repository/InteractionHistoryRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/repository/InteractionHistoryRepository.kt
@@ -1,6 +1,9 @@
 package com.depromeet.whatnow.domains.interactionhistory.repository
 
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface InteractionHistoryRepository : JpaRepository<InteractionHistory, Long>
+interface InteractionHistoryRepository : JpaRepository<InteractionHistory, Long> {
+    fun findAllByUserIdAndPromiseIdAndInteractionType(userId: Long, promiseId: Long, interactionType: InteractionType): List<InteractionHistory>
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
@@ -5,16 +5,19 @@ import com.depromeet.whatnow.common.aop.verify.CheckUserParticipation
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import com.depromeet.whatnow.domains.interactionhistory.adapter.InteractionHistoryAdapter
 import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
+import org.springframework.transaction.annotation.Transactional
 
 @DomainService
 class InteractionHistoryDomainService(
     val interactionHistoryAdapter: InteractionHistoryAdapter,
 ) {
+    @Transactional
     fun sendInteraction(promiseId: Long, interactionType: InteractionType, userId: Long, targetUserId: Long) {
         interactionHistoryAdapter.save(InteractionHistory.of(promiseId, interactionType, userId, targetUserId))
     }
 
     @CheckUserParticipation
+    @Transactional(readOnly = true)
     fun queryAllByInteractionType(userId: Long, promiseId: Long, interactionType: InteractionType): List<InteractionHistory> {
         return interactionHistoryAdapter.queryAllByInteractionType(userId, promiseId, interactionType)
     }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
@@ -1,0 +1,15 @@
+package com.depromeet.whatnow.domains.interactionhistory.service
+
+import com.depromeet.whatnow.annotation.DomainService
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.domains.interactionhistory.adapter.InteractionHistoryAdapter
+import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
+
+@DomainService
+class InteractionHistoryDomainService(
+    val interactionHistoryAdapter: InteractionHistoryAdapter,
+) {
+    fun sendInteraction(promiseId: Long, interactionType: InteractionType, userId: Long, targetUserId: Long) {
+        interactionHistoryAdapter.save(InteractionHistory.of(promiseId, interactionType, userId, targetUserId))
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/interactionhistory/service/InteractionHistoryDomainService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.interactionhistory.service
 
 import com.depromeet.whatnow.annotation.DomainService
+import com.depromeet.whatnow.common.aop.verify.CheckUserParticipation
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import com.depromeet.whatnow.domains.interactionhistory.adapter.InteractionHistoryAdapter
 import com.depromeet.whatnow.domains.interactionhistory.domain.InteractionHistory
@@ -11,5 +12,10 @@ class InteractionHistoryDomainService(
 ) {
     fun sendInteraction(promiseId: Long, interactionType: InteractionType, userId: Long, targetUserId: Long) {
         interactionHistoryAdapter.save(InteractionHistory.of(promiseId, interactionType, userId, targetUserId))
+    }
+
+    @CheckUserParticipation
+    fun queryAllByInteractionType(userId: Long, promiseId: Long, interactionType: InteractionType): List<InteractionHistory> {
+        return interactionHistoryAdapter.queryAllByInteractionType(userId, promiseId, interactionType)
     }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainServiceTest.kt
@@ -1,0 +1,38 @@
+package com.depromeet.whatnow.domains.interaction.service
+
+import com.depromeet.whatnow.config.DomainIntegrateSpringBootTest
+import com.depromeet.whatnow.domains.interaction.adapter.InteractionAdapter
+import com.depromeet.whatnow.domains.interaction.domain.Interaction
+import com.depromeet.whatnow.domains.interaction.domain.InteractionType
+import com.depromeet.whatnow.helper.CunCurrencyExecutorHelper
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+import java.util.concurrent.atomic.AtomicLong
+
+@DomainIntegrateSpringBootTest
+@TestPropertySource(properties = ["ableCheckUserParticipation=false"])
+class InteractionDomainServiceTest {
+    @Autowired lateinit var interactionDomainService: InteractionDomainService
+
+    @Autowired lateinit var interactionAdapter: InteractionAdapter
+
+    @Test
+    fun `분산락 적용시 동시요청에 올바르게 카운트가 증가해야한다`() {
+        // given
+        interactionAdapter.save(Interaction(InteractionType.HEART, 1L, 1L, 0L))
+        val successCount = AtomicLong()
+
+        // when
+        CunCurrencyExecutorHelper.execute(
+            { interactionDomainService.increment(1L, 1L, InteractionType.HEART ) },
+            successCount
+        )
+
+        // then
+        val interaction = interactionAdapter.queryInteraction(1L, 1L, InteractionType.HEART)
+        assertThat(interaction.count).isEqualTo(successCount.toLong())
+    }
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/interaction/service/InteractionDomainServiceTest.kt
@@ -6,7 +6,6 @@ import com.depromeet.whatnow.domains.interaction.domain.Interaction
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
 import com.depromeet.whatnow.helper.CunCurrencyExecutorHelper
 import org.assertj.core.api.Assertions.assertThat
-
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.TestPropertySource
@@ -27,8 +26,8 @@ class InteractionDomainServiceTest {
 
         // when
         CunCurrencyExecutorHelper.execute(
-            { interactionDomainService.increment(1L, 1L, InteractionType.HEART ) },
-            successCount
+            { interactionDomainService.increment(1L, 1L, InteractionType.HEART) },
+            successCount,
         )
 
         // then


### PR DESCRIPTION
## 개요
- close #94

## 작업사항
- 인터렉션 비지니스 로직을 구현하였습니다.
1. PromiseUserRegisterEvent를 받아 인터렉션을 init한다.
2. 인터렉션 요청받으면 인터렉션 히스토리에 내역을 생성함과 동시에 이벤트(InteractionHistoryRegisterEvent)를 발행하고 202를 응답한다
3. 이벤트 핸들러에서 Async로 인터렉션에 increment해준다. (이 때 동시성 문제 발행 가능성에 따라 redis 락 사용)

- 해당 유저가 해당 약속에 있는지 체크하는 AOP 생성 (`CheckUserParticipation`어노테이션 사용)

## 변경로직
- 내용을 적어주세요.