### PR TITLE
[DPMBE-86] ContentCachingRequestWrapper캐싱 이슈 해결

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/WhatnowApiApplication.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/WhatnowApiApplication.kt
@@ -2,10 +2,20 @@ package com.depromeet.whatnow
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.web.filter.ForwardedHeaderFilter
 
 @SpringBootApplication
-class WhatnowApiApplication
+class WhatnowApiApplication {
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            runApplication<WhatnowApiApplication>(*args)
+        }
+    }
 
-fun main(args: Array<String>) {
-    runApplication<WhatnowApiApplication>(*args)
+    @Bean
+    fun forwardedHeaderFilter(): ForwardedHeaderFilter {
+        return ForwardedHeaderFilter()
+    }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -56,7 +56,14 @@ class PromiseReadUseCase(
                 }
 
                 PromiseType.DELETED -> {
+                    // TODO
                     // Do nothing for deleted promises.
+                }
+                null -> {
+                    // TODO
+                }
+                else -> {
+                    // TODO
                 }
             }
         }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/rateLimit/IPRateLimiter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/rateLimit/IPRateLimiter.kt
@@ -27,7 +27,7 @@ class IPRateLimiter(
     }
 
     private val configSupplierForUser: Supplier<BucketConfiguration>
-        private get() {
+        get() {
             val refill: Refill = Refill.greedy(greedyRefill, Duration.ofMinutes(1))
             val limit: Bandwidth = Bandwidth.classic(overdraft, refill)
             return Supplier {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/rateLimit/UserRateLimiter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/rateLimit/UserRateLimiter.kt
@@ -23,11 +23,11 @@ class UserRateLimiter(
 
     fun resolveBucket(key: String): Bucket {
         val configSupplier = configSupplierForUser
-        return buckets!!.builder().build(key, configSupplier)
+        return buckets.builder().build(key, configSupplier)
     }
 
     private val configSupplierForUser: Supplier<BucketConfiguration>
-        private get() {
+        get() {
             val refill = Refill.greedy(greedyRefill, Duration.ofMinutes(1))
             val limit = Bandwidth.classic(overdraft, refill)
             return Supplier {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/HttpContentCacheFilter.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/HttpContentCacheFilter.kt
@@ -1,0 +1,26 @@
+package com.depromeet.whatnow.config.security
+
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.io.IOException
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class HttpContentCacheFilter : OncePerRequestFilter() {
+    @Throws(ServletException::class, IOException::class)
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        chain: FilterChain,
+    ) {
+        val wrappingRequest = ContentCachingRequestWrapper(request)
+        val wrappingResponse = ContentCachingResponseWrapper(response)
+        chain.doFilter(wrappingRequest, wrappingResponse)
+        wrappingResponse.copyBodyToResponse()
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/ServletFilterConfig.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/security/ServletFilterConfig.kt
@@ -1,0 +1,51 @@
+package com.depromeet.whatnow.config.security
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer
+import org.springframework.web.filter.ForwardedHeaderFilter
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter
+import javax.servlet.Filter
+
+@Configuration
+@Profile("prod", "staging", "dev")
+class ServletFilterConfig(
+    val forwardedHeaderFilter: ForwardedHeaderFilter,
+    val httpContentCacheFilter: HttpContentCacheFilter,
+) : WebMvcConfigurer {
+    @Bean
+    fun securityFilterChain(
+        @Qualifier(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+        securityFilter: Filter?,
+    ): FilterRegistrationBean<Filter> {
+        val registration: FilterRegistrationBean<Filter> = FilterRegistrationBean(securityFilter)
+        registration.order = Int.MAX_VALUE - 3
+        registration.setName(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+        return registration
+    }
+
+    @Bean
+    fun setResourceUrlEncodingFilter(): FilterRegistrationBean<ResourceUrlEncodingFilter> {
+        val registrationBean: FilterRegistrationBean<ResourceUrlEncodingFilter> = FilterRegistrationBean(ResourceUrlEncodingFilter())
+        registrationBean.order = Int.MAX_VALUE - 2
+        return registrationBean
+    }
+
+    @Bean
+    fun setForwardedHeaderFilterOrder(): FilterRegistrationBean<ForwardedHeaderFilter> {
+        val registrationBean: FilterRegistrationBean<ForwardedHeaderFilter> = FilterRegistrationBean(forwardedHeaderFilter)
+        registrationBean.order = Int.MAX_VALUE - 1
+        return registrationBean
+    }
+
+    @Bean
+    fun setHttpContentCacheFilterOrder(): FilterRegistrationBean<HttpContentCacheFilter> {
+        val registrationBean: FilterRegistrationBean<HttpContentCacheFilter> = FilterRegistrationBean(httpContentCacheFilter)
+        registrationBean.order = Int.MAX_VALUE
+        return registrationBean
+    }
+}


### PR DESCRIPTION
## 개요
- close #118 

## 작업사항
- httpServletContentFilter 를 추가해주었습니다.
```
    @Bean
    fun securityFilterChain(
        @Qualifier(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
        securityFilter: Filter?,
    ): FilterRegistrationBean<Filter> {
        val registration: FilterRegistrationBean<Filter> = FilterRegistrationBean(securityFilter)
        registration.order = Int.MAX_VALUE - 3
        registration.setName(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
        return registration
    }

```
순서 크기가 중요한 거라서 Int.MAX_VALUE 로 해논거겠죠? 좀 큰 값이라 당황..

## 변경로직
- forwardHeaderFilter를 main 에서 Bean di 했는데 코틀린 특성상 메인 함수 내에서 fun 함수가 금지돼 있습니다. 
- 그래서 동행객체로 따로 선언해주었습니다. 이게 맞는지는 모르겠어요