### PR TITLE
[DPMBE-91]몽고디비 스트림 커넥션 오류 수정

### DIFF
--- a/Whatnow-Api/src/main/resources/application.yml
+++ b/Whatnow-Api/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     include:
       - infrastructure
       - domain
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+      - org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration
 springdoc:
   default-produces-media-type: application/json
   default-consumes-media-type: application/json

--- a/Whatnow-Api/src/main/resources/application.yml
+++ b/Whatnow-Api/src/main/resources/application.yml
@@ -3,10 +3,6 @@ spring:
     include:
       - infrastructure
       - domain
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
-      - org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration
 springdoc:
   default-produces-media-type: application/json
   default-consumes-media-type: application/json

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/WhatnowDomainApplication.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/WhatnowDomainApplication.kt
@@ -1,12 +1,9 @@
 package com.depromeet.whatnow
 
-import com.depromeet.whatnow.config.mongo.MongoConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.Import
 
 @SpringBootApplication
-@Import(MongoConfig::class)
 class WhatnowDomainApplication
 
 fun main(args: Array<String>) {

--- a/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/Whatnow-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -14,6 +14,10 @@ data:
     username: ${MONGO_USERNAME}
     password: ${MONGO_PASSWORD}
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+      - org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration
   redis:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}


### PR DESCRIPTION
## 개요
- close #128 

## 작업사항
- Spring 에서는 MongoDriver 가 발견되면 MongoAutoConfiguration이 default 로 설정되는 이슈가 있습니다. 
default 는  localhost:27017 로 설정이 됩니다. 본인 로컬로 켜진 몽고DB 로 연결되버립니다. MongoAtlas 로 연결하려면 저 설정을 꺼둬야 합니다.

- @SpringBootApplication(exclude = [MongoAutoConfiguration::class, MongoDataAutoConfiguration::class])
설정을 해도 반영이 안되더라구요. yml 세팅이 먹혀서 일단 이렇게 세팅했습니다.

<img width="678" alt="image" src="https://github.com/depromeet/Whatnow-Api/assets/54030889/a04515d4-de51-4fd3-9605-13064d65fe38">

[stackoverflow  [Mongo tries to connect automatically to port 27017(localhost)](https://www.google.com/search?client=firefox-b-d&q=EmbeddedMongoServer)