### PR TITLE
[DPMBE-98] ImageComment Enum에 이미지 링크를 추가하고 확인할 수 있도록 한다.

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -1,7 +1,9 @@
 package com.depromeet.whatnow.api.image.controller
 
+import com.depromeet.whatnow.api.image.dto.ImageCommentElement
 import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
+import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.s3.ImageFileExtension
@@ -25,6 +27,7 @@ import javax.validation.Valid
 class ImageController(
     val getPresignedUrlUseCase: GetPresignedUrlUseCase,
     val successUseCase: ImageUploadSuccessUseCase,
+    val imageCommentReadUseCase: ImageCommentReadUseCase,
 ) {
     @Operation(summary = "약속 이미지 업로드 Presigned URL 발급")
     @GetMapping("/images/promises/{promiseId}")
@@ -59,5 +62,11 @@ class ImageController(
     @PostMapping("/images/{imageKey}/users/me")
     fun userUploadImageSuccess(@PathVariable imageKey: String) {
         successUseCase.userUploadImageSuccess(imageKey)
+    }
+
+    @Operation(summary = "이미지 코멘트를 이넘으로 확인합니다. 주의!! 스웨거 이넘 예시 값과 실제 요청했을 때 값이 달라요 실제 요청값 기준으로 해주세요")
+    @GetMapping("/images/comments")
+    fun getImageCommentType(): List<ImageCommentElement> {
+        return imageCommentReadUseCase.execute()
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageCommentElement.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/dto/ImageCommentElement.kt
@@ -1,0 +1,9 @@
+package com.depromeet.whatnow.api.image.dto
+
+import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
+import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
+
+data class ImageCommentElement(
+    val promiseUserType: PromiseUserType,
+    val comments: List<PromiseImageCommentType>,
+)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageCommentReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageCommentReadUseCase.kt
@@ -1,0 +1,18 @@
+package com.depromeet.whatnow.api.image.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.image.dto.ImageCommentElement
+import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
+
+@UseCase
+class ImageCommentReadUseCase {
+    fun execute(): List<ImageCommentElement> {
+        return PromiseImageCommentType.values().groupBy {
+                p ->
+            p.promiseUserType
+        }.map {
+                (k, value) ->
+            ImageCommentElement(k, value)
+        }
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/PromiseImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/PromiseImageControllerTest.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.image.controller
 
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
+import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.s3.ImageFileExtension
@@ -27,6 +28,9 @@ class PromiseImageControllerTest {
 
     @MockBean
     lateinit var successUseCase: ImageUploadSuccessUseCase
+
+    @MockBean
+    lateinit var imageCommentReadUseCase: ImageCommentReadUseCase
 
     @Autowired
     lateinit var mockMvc: MockMvc

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
@@ -27,6 +27,8 @@ const val LOCAL = "local"
 const val WITHDRAW_PREFIX = "withdraw"
 
 const val IMAGE_DOMAIN = "https://image.whatnow.kr"
+const val ASSERT_IMAGE_DOMAIN = "https://image.whatnow.kr/assert"
+
 const val REDIS_EXPIRE_EVENT_PATTERN = "__keyevent@*__:expired"
 
 val SWAGGER_PATTERNS = arrayOf(

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImageCommentType.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImageCommentType.kt
@@ -1,19 +1,28 @@
 package com.depromeet.whatnow.domains.image.domain
 
+import com.depromeet.whatnow.consts.ASSERT_IMAGE_DOMAIN
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
+import com.fasterxml.jackson.annotation.JsonFormat
 
-enum class PromiseImageCommentType(val value: String, val promiseUserType: PromiseUserType?) {
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+enum class PromiseImageCommentType(
+    val promiseUserType: PromiseUserType,
+    val kr: String,
+    val code: String,
+    val image: String,
+    val imageSmall: String,
+) {
     // Can LATE
-    RUNNING("달려가는 중️", PromiseUserType.LATE),
-    GASPING("헐레벌떡", PromiseUserType.LATE),
-    LEAVE_SOME("남겨놔!", PromiseUserType.LATE),
-    WAIT_A_BIT("조금만 기다려", PromiseUserType.LATE),
-    SORRY_LATE("늦어서 미안해", PromiseUserType.LATE),
+    RUNNING(PromiseUserType.LATE, "달려가는 중️", "RUNNING", "$ASSERT_IMAGE_DOMAIN/comments/RUNNING.svg", "$ASSERT_IMAGE_DOMAIN/comments/RUNNING_SMALL.svg"),
+    GASPING(PromiseUserType.LATE, "헐레벌떡", "GASPING", "$ASSERT_IMAGE_DOMAIN/comments/GASPING.svg", "$ASSERT_IMAGE_DOMAIN/comments/GASPING_SMALL.svg"),
+    LEAVE_SOME(PromiseUserType.LATE, "남겨놔!", "LEAVE_SOME", "$ASSERT_IMAGE_DOMAIN/comments/LEAVE_SOME.svg", "$ASSERT_IMAGE_DOMAIN/comments/LEAVE_SOME_SMALL.svg"),
+    WAIT_A_BIT(PromiseUserType.LATE, "조금만 기다려", "WAIT_A_BIT", "$ASSERT_IMAGE_DOMAIN/comments/WAIT_A_BIT.svg", "$ASSERT_IMAGE_DOMAIN/comments/WAIT_A_BIT_SMALL.svg"),
+    SORRY_LATE(PromiseUserType.LATE, "늦어서 미안해", "SORRY_LATE", "$ASSERT_IMAGE_DOMAIN/comments/SORRY_LATE.svg", "$ASSERT_IMAGE_DOMAIN/comments/SORRY_LATE_SMALL.svg"),
 
     // Can WAIT
-    WHAT_ARE_YOU_DOING("뭐해 심심해", PromiseUserType.WAIT),
-    WHAT_TIME_IS_IT_NOW("지금이 몇시야!", PromiseUserType.WAIT),
-    DID_YOU_COME("왔나..?", PromiseUserType.WAIT),
-    I_LL_EAT_FIRST("먼저 먹을게~", PromiseUserType.WAIT),
-    WHERE_ARE_YOU("너 어디야?", PromiseUserType.WAIT),
+    WHAT_ARE_YOU_DOING(PromiseUserType.WAIT, "뭐해 심심해", "WHAT_ARE_YOU_DOING", "$ASSERT_IMAGE_DOMAIN/comments/WHAT_ARE_YOU_DOING.svg", "$ASSERT_IMAGE_DOMAIN/comments/WHAT_ARE_YOU_DOING_SMALL.svg"),
+    WHAT_TIME_IS_IT_NOW(PromiseUserType.WAIT, "지금이 몇시야!", "WHAT_TIME_IS_IT_NOW", "$ASSERT_IMAGE_DOMAIN/comments/WHAT_TIME_IS_IT_NOW.svg", "$ASSERT_IMAGE_DOMAIN/comments/WHAT_TIME_IS_IT_NOW_SMALL.svg"),
+    DID_YOU_COME(PromiseUserType.WAIT, "왔나..?", "DID_YOU_COME", "$ASSERT_IMAGE_DOMAIN/comments/DID_YOU_COME.svg", "$ASSERT_IMAGE_DOMAIN/comments/DID_YOU_COME_SMALL.svg"),
+    I_LL_EAT_FIRST(PromiseUserType.WAIT, "먼저 먹을게~", "I_LL_EAT_FIRST", "$ASSERT_IMAGE_DOMAIN/comments/I_LL_EAT_FIRST.svg", "$ASSERT_IMAGE_DOMAIN/comments/I_LL_EAT_FIRST_SMALL.svg"),
+    WHERE_ARE_YOU(PromiseUserType.WAIT, "너 어디야?", "WHERE_ARE_YOU", "$ASSERT_IMAGE_DOMAIN/comments/WHERE_ARE_YOU.svg", "$ASSERT_IMAGE_DOMAIN/comments/WHERE_ARE_YOU_SMALL.svg"),
 }


### PR DESCRIPTION
## 개요
- close #142 

## 작업사항
- 서버에서 이미지 코멘트 타입에 따른 파일 링크를 조회하도록 추가하였습니다 
