### PR TITLE
[DPMBE-100] 약속 이미지에 Coordainate(위경도)를 제거한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -5,7 +5,6 @@ import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import io.swagger.v3.oas.annotations.Operation
@@ -14,11 +13,9 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import javax.validation.Valid
 
 @RestController
 @Tag(name = "6. [이미지]")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -52,10 +52,8 @@ class ImageController(
         @PathVariable promiseId: Long,
         @PathVariable imageKey: String,
         @RequestParam promiseImageCommentType: PromiseImageCommentType,
-        @RequestBody @Valid
-        userLocation: CoordinateVo,
     ) {
-        successUseCase.promiseUploadImageSuccess(promiseId, imageKey, promiseImageCommentType, userLocation)
+        successUseCase.promiseUploadImageSuccess(promiseId, imageKey, promiseImageCommentType)
     }
 
     @Operation(summary = "유저 프로필 이미지 업로드 성공 요청")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
@@ -13,11 +13,10 @@ class ImageUploadSuccessUseCase(
     fun promiseUploadImageSuccess(
         promiseId: Long,
         imageKey: String,
-        promiseImageCommentType: PromiseImageCommentType,
-        userLocation: CoordinateVo,
+        promiseImageCommentType: PromiseImageCommentType
     ) {
         val currentUserId: Long = SecurityUtils.currentUserId
-        imageDomainService.promiseImageUploadSuccess(currentUserId, promiseId, imageKey, promiseImageCommentType, userLocation)
+        imageDomainService.promiseImageUploadSuccess(currentUserId, promiseId, imageKey, promiseImageCommentType)
     }
 
     fun userUploadImageSuccess(imageKey: String) {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
@@ -1,7 +1,6 @@
 package com.depromeet.whatnow.api.image.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
@@ -13,7 +12,7 @@ class ImageUploadSuccessUseCase(
     fun promiseUploadImageSuccess(
         promiseId: Long,
         imageKey: String,
-        promiseImageCommentType: PromiseImageCommentType
+        promiseImageCommentType: PromiseImageCommentType,
     ) {
         val currentUserId: Long = SecurityUtils.currentUserId
         imageDomainService.promiseImageUploadSuccess(currentUserId, promiseId, imageKey, promiseImageCommentType)

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageUploadSuccessUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageUploadSuccessUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.api.image.usecase
 
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
 import org.assertj.core.api.Assertions.assertThatCode
@@ -33,13 +32,11 @@ class PromiseImageUploadSuccessUseCaseTest {
     @Test
     fun `약속 이미지 업로드 성공 요청시 정상적이라면 에러가 발생하지 않는다`() {
         // given
-        val coordinateVo = CoordinateVo(1.0, 1.0)
-
         // when
 
         // then
         assertThatCode {
-            imageUploadSuccessUseCase.promiseUploadImageSuccess(1, "imageKey", PromiseImageCommentType.SORRY_LATE, coordinateVo)
+            imageUploadSuccessUseCase.promiseUploadImageSuccess(1, "imageKey", PromiseImageCommentType.SORRY_LATE)
         }.doesNotThrowAnyException()
     }
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImage.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImage.kt
@@ -29,9 +29,6 @@ class PromiseImage(
     @Enumerated(EnumType.STRING)
     var promiseImageCommentType: PromiseImageCommentType,
 
-    @Embedded
-    var userLocation: CoordinateVo? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "promise_image_id")
@@ -43,10 +40,9 @@ class PromiseImage(
             promiseId: Long,
             uri: String,
             imageKey: String,
-            promiseImageCommentType: PromiseImageCommentType,
-            userLocation: CoordinateVo,
+            promiseImageCommentType: PromiseImageCommentType
         ): PromiseImage {
-            return PromiseImage(userId, promiseId, uri, imageKey, promiseImageCommentType, userLocation)
+            return PromiseImage(userId, promiseId, uri, imageKey, promiseImageCommentType)
         }
     }
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImage.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/PromiseImage.kt
@@ -2,10 +2,8 @@ package com.depromeet.whatnow.domains.image.domain
 
 import com.depromeet.whatnow.common.BaseTimeEntity
 import com.depromeet.whatnow.common.aop.event.Events
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.events.domainEvent.PromiseImageRegisterEvent
 import javax.persistence.Column
-import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -40,7 +38,7 @@ class PromiseImage(
             promiseId: Long,
             uri: String,
             imageKey: String,
-            promiseImageCommentType: PromiseImageCommentType
+            promiseImageCommentType: PromiseImageCommentType,
         ): PromiseImage {
             return PromiseImage(userId, promiseId, uri, imageKey, promiseImageCommentType)
         }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/service/ImageDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/service/ImageDomainService.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.domains.image.service
 
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.consts.IMAGE_DOMAIN
 import com.depromeet.whatnow.domains.image.adapter.PromiseImageAdapter
 import com.depromeet.whatnow.domains.image.adapter.UserImageAdapter
@@ -30,7 +29,7 @@ class ImageDomainService(
         userId: Long,
         promiseId: Long,
         imageKey: String,
-        promiseImageCommentType: PromiseImageCommentType
+        promiseImageCommentType: PromiseImageCommentType,
     ) {
         val promiseUser = promiseUserAdapter.findByPromiseIdAndUserId(promiseId, userId)
         validatePromiseUserType(promiseUser.promiseUserType!!, promiseImageCommentType)

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/service/ImageDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/service/ImageDomainService.kt
@@ -30,15 +30,14 @@ class ImageDomainService(
         userId: Long,
         promiseId: Long,
         imageKey: String,
-        promiseImageCommentType: PromiseImageCommentType,
-        userLocation: CoordinateVo,
+        promiseImageCommentType: PromiseImageCommentType
     ) {
         val promiseUser = promiseUserAdapter.findByPromiseIdAndUserId(promiseId, userId)
         validatePromiseUserType(promiseUser.promiseUserType!!, promiseImageCommentType)
 
         val imageUrl = IMAGE_DOMAIN + "/" + springEnvironmentHelper.activeProfile + "/" + "promise/$promiseId/$imageKey"
         promiseImageAdapter.save(
-            PromiseImage.of(promiseId, userId, imageUrl, imageKey, promiseImageCommentType, userLocation),
+            PromiseImage.of(promiseId, userId, imageUrl, imageKey, promiseImageCommentType),
         )
     }
 

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/adapter/PromisePromiseImageAdapterTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/adapter/PromisePromiseImageAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.domains.image.adapter
 
-import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.domains.image.domain.PromiseImage
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.repository.PromiseImageRepository
@@ -23,8 +22,7 @@ class PromisePromiseImageAdapterTest {
 
     @Test
     fun `약속 이미지 저장 시 정상적으로 저장된다`() {
-        val userLocation = CoordinateVo(37.2, 128.05)
-        val promiseImage = PromiseImage.of(1, 1, "imageUri", "imageKey", PromiseImageCommentType.RUNNING, userLocation)
+        val promiseImage = PromiseImage.of(1, 1, "imageUri", "imageKey", PromiseImageCommentType.RUNNING)
         given(promiseImageRepository.save(Mockito.any(PromiseImage::class.java)))
             .willReturn(promiseImage)
 
@@ -37,6 +35,5 @@ class PromisePromiseImageAdapterTest {
         assertEquals(savedPromiseImage.uri, "imageUri")
         assertEquals(savedPromiseImage.imageKey, "imageKey")
         assertEquals(savedPromiseImage.promiseImageCommentType, PromiseImageCommentType.RUNNING)
-        assertEquals(savedPromiseImage.userLocation, userLocation)
     }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/service/PromiseImageDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/service/PromiseImageDomainServiceTest.kt
@@ -50,13 +50,12 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.LATE,
         )
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatCode {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING, userLocation)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
         }.doesNotThrowAnyException()
     }
 
@@ -69,13 +68,12 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.READY,
         )
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING, userLocation)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
         }.isInstanceOf(UploadBeforeTrackingException::class.java)
     }
 
@@ -88,13 +86,12 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.CANCEL,
         )
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING, userLocation)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
         }.isInstanceOf(CancelledUserUploadException::class.java)
     }
 
@@ -107,13 +104,12 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.LATE,
         )
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.DID_YOU_COME, userLocation)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.DID_YOU_COME)
         }.isInstanceOf(InvalidCommentTypeException::class.java)
     }
 
@@ -126,13 +122,12 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.WAIT,
         )
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.WAIT_A_BIT, userLocation)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.WAIT_A_BIT)
         }.isInstanceOf(InvalidCommentTypeException::class.java)
     }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/events/handler/PromisePromiseImageRegisterEventHandlerTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/events/handler/PromisePromiseImageRegisterEventHandlerTest.kt
@@ -34,11 +34,10 @@ class PromisePromiseImageRegisterEventHandlerTest {
     fun `약속 이미지 등록 성공 시 이미지 등록 이벤트가 발행되어야한다`() {
         // given
         val promiseUser = PromiseUser(1, 1, CoordinateVo(1.0, 1.0), PromiseUserType.LATE)
-        val userLocation = CoordinateVo(37.2, 128.05)
         given(promiseUserAdaptor.findByPromiseIdAndUserId(1, 1)).willReturn(promiseUser)
 
         // when
-        imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING, userLocation)
+        imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
 
         // then
         then(imageRegisterEventHandler).should(Mockito.times(1)).handleRegisterPictureEvent(any())


### PR DESCRIPTION
## 개요
- close #150 

## 작업사항
- 이미지를 좌표 상 위치에 고정시켜놓는줄 알고 위치값을 받았는데, 유저 위치에 따라 핀 대신 이미지로 바뀌는 거였네용

## 변경로직
- 내용을 적어주세요.