### PR TITLE
[DPMBE-76] 사진 삭제 기능을 추가한다 (S3에 이미지도 같이 삭제)

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -9,7 +9,6 @@ import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageDeleteUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageReadUseCase
-import com.depromeet.whatnow.api.image.usecase.UserImageDeleteUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import io.swagger.v3.oas.annotations.Operation
@@ -31,7 +30,7 @@ class ImageController(
     val successUseCase: ImageUploadSuccessUseCase,
     val imageCommentReadUseCase: ImageCommentReadUseCase,
     val promiseImageReadUseCase: PromiseImageReadUseCase,
-    val promiseImageDeleteUseCase: PromiseImageDeleteUseCase
+    val promiseImageDeleteUseCase: PromiseImageDeleteUseCase,
 ) {
     @Tag(name = "6-1 [약속 이미지]")
     @Operation(summary = "약속 이미지 업로드 Presigned URL 발급")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -31,8 +31,7 @@ class ImageController(
     val successUseCase: ImageUploadSuccessUseCase,
     val imageCommentReadUseCase: ImageCommentReadUseCase,
     val promiseImageReadUseCase: PromiseImageReadUseCase,
-    val promiseImageDeleteUseCase: PromiseImageDeleteUseCase,
-    val userImageDeleteUseCase: UserImageDeleteUseCase,
+    val promiseImageDeleteUseCase: PromiseImageDeleteUseCase
 ) {
     @Tag(name = "6-1 [약속 이미지]")
     @Operation(summary = "약속 이미지 업로드 Presigned URL 발급")
@@ -98,12 +97,5 @@ class ImageController(
     @PostMapping("/{imageKey}/users/me")
     fun userUploadImageSuccess(@PathVariable imageKey: String, @RequestParam fileExtension: ImageFileExtension) {
         successUseCase.userUploadImageSuccess(imageKey, fileExtension)
-    }
-
-    @Tag(name = "6-2 [유저 이미지]")
-    @Operation(summary = "이미지 키를 통해 유저 이미지를 삭제합니다.")
-    @DeleteMapping("/{imageKey}/users/me")
-    fun deleteUserImage(@PathVariable imageKey: String) {
-        userImageDeleteUseCase.execute(imageKey)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/controller/ImageController.kt
@@ -7,12 +7,15 @@ import com.depromeet.whatnow.api.image.dto.PromiseImageResponse
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
+import com.depromeet.whatnow.api.image.usecase.PromiseImageDeleteUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageReadUseCase
+import com.depromeet.whatnow.api.image.usecase.UserImageDeleteUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,6 +31,8 @@ class ImageController(
     val successUseCase: ImageUploadSuccessUseCase,
     val imageCommentReadUseCase: ImageCommentReadUseCase,
     val promiseImageReadUseCase: PromiseImageReadUseCase,
+    val promiseImageDeleteUseCase: PromiseImageDeleteUseCase,
+    val userImageDeleteUseCase: UserImageDeleteUseCase,
 ) {
     @Tag(name = "6-1 [약속 이미지]")
     @Operation(summary = "약속 이미지 업로드 Presigned URL 발급")
@@ -45,9 +50,10 @@ class ImageController(
     fun promiseUploadImageSuccess(
         @PathVariable promiseId: Long,
         @PathVariable imageKey: String,
+        @RequestParam fileExtension: ImageFileExtension,
         @RequestParam promiseImageCommentType: PromiseImageCommentType,
     ) {
-        successUseCase.promiseUploadImageSuccess(promiseId, imageKey, promiseImageCommentType)
+        successUseCase.promiseUploadImageSuccess(promiseId, imageKey, fileExtension, promiseImageCommentType)
     }
 
     @Tag(name = "6-1 [약속 이미지]")
@@ -71,6 +77,13 @@ class ImageController(
         return promiseImageReadUseCase.getImageByImageKey(imageKey)
     }
 
+    @Tag(name = "6-1 [약속 이미지]")
+    @Operation(summary = "이미지 키를 통해 약속 이미지를 삭제합니다.")
+    @DeleteMapping("/{imageKey}/promises/{promiseId}")
+    fun deletePromiseImage(@PathVariable promiseId: Long, @PathVariable imageKey: String) {
+        promiseImageDeleteUseCase.execute(promiseId, imageKey)
+    }
+
     @Tag(name = "6-2 [유저 이미지]")
     @Operation(summary = "유저 프로필 이미지 업로드 Presigned URL 발급")
     @GetMapping("/users/me/presigned-url")
@@ -83,7 +96,14 @@ class ImageController(
     @Tag(name = "6-2 [유저 이미지]")
     @Operation(summary = "유저 프로필 이미지 업로드 성공 요청")
     @PostMapping("/{imageKey}/users/me")
-    fun userUploadImageSuccess(@PathVariable imageKey: String) {
-        successUseCase.userUploadImageSuccess(imageKey)
+    fun userUploadImageSuccess(@PathVariable imageKey: String, @RequestParam fileExtension: ImageFileExtension) {
+        successUseCase.userUploadImageSuccess(imageKey, fileExtension)
+    }
+
+    @Tag(name = "6-2 [유저 이미지]")
+    @Operation(summary = "이미지 키를 통해 유저 이미지를 삭제합니다.")
+    @DeleteMapping("/{imageKey}/users/me")
+    fun deleteUserImage(@PathVariable imageKey: String) {
+        userImageDeleteUseCase.execute(imageKey)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
@@ -3,19 +3,19 @@ package com.depromeet.whatnow.api.image.usecase
 import com.depromeet.whatnow.annotation.UseCase
 import com.depromeet.whatnow.api.image.dto.ImageUrlResponse
 import com.depromeet.whatnow.config.s3.ImageFileExtension
-import com.depromeet.whatnow.config.s3.S3UploadPresignedUrlService
+import com.depromeet.whatnow.config.s3.S3Service
 import com.depromeet.whatnow.config.security.SecurityUtils
 
 @UseCase
 class GetPresignedUrlUseCase(
-    val presignedUrlService: S3UploadPresignedUrlService,
+    val presignedUrlService: S3Service,
 ) {
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlResponse {
-        return ImageUrlResponse.from(presignedUrlService.forPromise(promiseId, fileExtension))
+        return ImageUrlResponse.from(presignedUrlService.getPresignedUrlForPromise(promiseId, fileExtension))
     }
 
     fun forUser(fileExtension: ImageFileExtension): ImageUrlResponse {
         val currentUserId = SecurityUtils.currentUserId
-        return ImageUrlResponse.from(presignedUrlService.forUser(currentUserId, fileExtension))
+        return ImageUrlResponse.from(presignedUrlService.getPresignedUrlForUser(currentUserId, fileExtension))
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/ImageUploadSuccessUseCase.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.image.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.config.security.SecurityUtils
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
@@ -12,14 +13,15 @@ class ImageUploadSuccessUseCase(
     fun promiseUploadImageSuccess(
         promiseId: Long,
         imageKey: String,
+        fileExtension: ImageFileExtension,
         promiseImageCommentType: PromiseImageCommentType,
     ) {
         val currentUserId: Long = SecurityUtils.currentUserId
-        imageDomainService.promiseImageUploadSuccess(currentUserId, promiseId, imageKey, promiseImageCommentType)
+        imageDomainService.promiseImageUploadSuccess(currentUserId, promiseId, imageKey, fileExtension, promiseImageCommentType)
     }
 
-    fun userUploadImageSuccess(imageKey: String) {
+    fun userUploadImageSuccess(imageKey: String, fileExtension: ImageFileExtension) {
         val currentUserId: Long = SecurityUtils.currentUserId
-        imageDomainService.userImageUploadSuccess(currentUserId, imageKey)
+        imageDomainService.userImageUploadSuccess(currentUserId, imageKey, fileExtension)
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageDeleteUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageDeleteUseCase.kt
@@ -1,0 +1,15 @@
+package com.depromeet.whatnow.api.image.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.image.service.ImageDomainService
+
+@UseCase
+class PromiseImageDeleteUseCase(
+    val imageDomainService: ImageDomainService,
+) {
+    fun execute(promiseId: Long, imageKey: String) {
+        val userId = SecurityUtils.currentUserId
+        imageDomainService.deleteForPromise(userId, promiseId, imageKey)
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/UserImageDeleteUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/UserImageDeleteUseCase.kt
@@ -1,0 +1,15 @@
+package com.depromeet.whatnow.api.image.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.image.service.ImageDomainService
+
+@UseCase
+class UserImageDeleteUseCase(
+    val imageDomainService: ImageDomainService,
+) {
+    fun execute(imageKey: String) {
+        val userId = SecurityUtils.currentUserId
+        imageDomainService.deleteForUser(userId, imageKey)
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -3,17 +3,16 @@ package com.depromeet.whatnow.api.image.controller
 import com.depromeet.whatnow.api.image.usecase.GetPresignedUrlUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
+import com.depromeet.whatnow.api.image.usecase.PromiseImageDeleteUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageReadUseCase
-import com.depromeet.whatnow.common.vo.CoordinateVo
+import com.depromeet.whatnow.api.image.usecase.UserImageDeleteUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -36,11 +35,14 @@ class ImageControllerTest {
     @MockBean
     lateinit var promiseImageReadUseCase: PromiseImageReadUseCase
 
-    @Autowired
-    lateinit var mockMvc: MockMvc
+    @MockBean
+    lateinit var promiseImageDeleteUseCase: PromiseImageDeleteUseCase
+
+    @MockBean
+    lateinit var userImageDeleteUseCase: UserImageDeleteUseCase
 
     @Autowired
-    lateinit var objectMapper: ObjectMapper
+    lateinit var mockMvc: MockMvc
 
     @Test
     fun `약속 이미지 presignedUrl 요청에 성공하면 200을 응답한다`() {
@@ -76,15 +78,13 @@ class ImageControllerTest {
         // given
         val promiseId = 1
         val imageKey = "imageKey"
+        val fileExtension = ImageFileExtension.JPEG.name
         val promiseImageCommentType = PromiseImageCommentType.SORRY_LATE
-        val userLocation = CoordinateVo(127.3, 23.0)
-
         // when, then
         mockMvc.perform(
             MockMvcRequestBuilders.post("/v1/images/{imageKey}/promises/{promiseId}", imageKey, promiseId)
-                .param("promiseImageCommentType", promiseImageCommentType.name)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userLocation)),
+                .param("fileExtension", fileExtension)
+                .param("promiseImageCommentType", promiseImageCommentType.name),
         )
             .andExpect(status().isOk)
             .andDo { print(it) }
@@ -94,10 +94,12 @@ class ImageControllerTest {
     fun `유저 프로필 업로드 성공 요청에 정상적으로 200을 반환한다`() {
         // given
         val imageKey = "imageKey"
+        val fileExtension = ImageFileExtension.JPEG.name
 
         // when, then
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/v1/images/{imageKey}/users/me", imageKey),
+            MockMvcRequestBuilders.post("/v1/images/{imageKey}/users/me", imageKey)
+                .param("fileExtension", fileExtension),
         )
             .andExpect(status().isOk)
             .andDo { print(it) }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -5,7 +5,6 @@ import com.depromeet.whatnow.api.image.usecase.ImageCommentReadUseCase
 import com.depromeet.whatnow.api.image.usecase.ImageUploadSuccessUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageDeleteUseCase
 import com.depromeet.whatnow.api.image.usecase.PromiseImageReadUseCase
-import com.depromeet.whatnow.api.image.usecase.UserImageDeleteUseCase
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import org.junit.jupiter.api.Test

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/controller/ImageControllerTest.kt
@@ -38,9 +38,6 @@ class ImageControllerTest {
     @MockBean
     lateinit var promiseImageDeleteUseCase: PromiseImageDeleteUseCase
 
-    @MockBean
-    lateinit var userImageDeleteUseCase: UserImageDeleteUseCase
-
     @Autowired
     lateinit var mockMvc: MockMvc
 

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.depromeet.whatnow.api.image.usecase
 
 import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.config.s3.ImageUrlDto
-import com.depromeet.whatnow.config.s3.S3UploadPresignedUrlService
+import com.depromeet.whatnow.config.s3.S3Service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ import org.springframework.security.test.context.support.WithMockUser
 @ExtendWith(MockitoExtension::class)
 class GetPresignedUrlUseCaseTest {
     @Mock
-    lateinit var presignedUrlService: S3UploadPresignedUrlService
+    lateinit var presignedUrlService: S3Service
 
     @InjectMocks
     lateinit var getPresignedUrlUseCase: GetPresignedUrlUseCase
@@ -35,7 +35,7 @@ class GetPresignedUrlUseCaseTest {
     @Test
     fun `약속 이미지 PresignUrl 을 요청하면 url 을 반환한다`() {
         // given
-        given(presignedUrlService.forPromise(1, ImageFileExtension.JPEG)).willReturn(
+        given(presignedUrlService.getPresignedUrlForPromise(1, ImageFileExtension.JPEG)).willReturn(
             ImageUrlDto(
                 url = "https://whatnow.kr/1.jpg",
                 key = "1.jpg",
@@ -53,7 +53,7 @@ class GetPresignedUrlUseCaseTest {
     @WithMockUser(username = "1")
     fun `유저 프로필 PresignUrl 을 요청하면 url 을 반환한다`() {
         // given
-        given(presignedUrlService.forUser(1, ImageFileExtension.JPEG)).willReturn(
+        given(presignedUrlService.getPresignedUrlForUser(1, ImageFileExtension.JPEG)).willReturn(
             ImageUrlDto(
                 url = "https://whatnow.kr/1.jpg",
                 key = "1.jpg",

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageReadUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.api.image.usecase
 
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImage
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
@@ -46,6 +47,7 @@ class PromiseImageReadUseCaseTest {
             promiseId = 1,
             uri = "https://image/whatnow.kr/$imageKey1.jpg",
             imageKey = imageKey1,
+            fileExtension = ImageFileExtension.JPG,
             promiseImageCommentType = PromiseImageCommentType.DID_YOU_COME,
         )
         val imageKey2 = "7e74f27e-0252-23ds-a2f2-58s1b5cce9c3"
@@ -54,6 +56,7 @@ class PromiseImageReadUseCaseTest {
             promiseId = 1,
             uri = "https://image/whatnow.kr/$imageKey2.jpg",
             imageKey = imageKey2,
+            fileExtension = ImageFileExtension.JPG,
             promiseImageCommentType = PromiseImageCommentType.DID_YOU_COME,
         )
         val promiseUser1 = PromiseUser(
@@ -69,6 +72,7 @@ class PromiseImageReadUseCaseTest {
             promiseId = 1,
             uri = "https://image/whatnow.kr/$imageKey3.jpg",
             imageKey = imageKey3,
+            fileExtension = ImageFileExtension.JPG,
             promiseImageCommentType = PromiseImageCommentType.RUNNING,
         )
         val imageKey4 = "7e74f27e-0252-23ds-a2f2-o50s1b5cce9c3"
@@ -77,6 +81,7 @@ class PromiseImageReadUseCaseTest {
             promiseId = 1,
             uri = "https://image/whatnow.kr/$imageKey4.jpg",
             imageKey = imageKey4,
+            fileExtension = ImageFileExtension.JPG,
             promiseImageCommentType = PromiseImageCommentType.RUNNING,
         )
         val promiseUser2 = PromiseUser(

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageUploadSuccessUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/image/usecase/PromiseImageUploadSuccessUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.api.image.usecase
 
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
 import org.assertj.core.api.Assertions.assertThatCode
@@ -36,7 +37,7 @@ class PromiseImageUploadSuccessUseCaseTest {
 
         // then
         assertThatCode {
-            imageUploadSuccessUseCase.promiseUploadImageSuccess(1, "imageKey", PromiseImageCommentType.SORRY_LATE)
+            imageUploadSuccessUseCase.promiseUploadImageSuccess(1, "imageKey", ImageFileExtension.JPG, PromiseImageCommentType.SORRY_LATE)
         }.doesNotThrowAnyException()
     }
 
@@ -48,7 +49,7 @@ class PromiseImageUploadSuccessUseCaseTest {
 
         // then
         assertThatCode {
-            imageUploadSuccessUseCase.userUploadImageSuccess("imageKey")
+            imageUploadSuccessUseCase.userUploadImageSuccess("imageKey", ImageFileExtension.JPG)
         }.doesNotThrowAnyException()
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/PromiseImageAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/PromiseImageAdapter.kt
@@ -2,6 +2,7 @@ package com.depromeet.whatnow.domains.image.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
 import com.depromeet.whatnow.domains.image.domain.PromiseImage
+import com.depromeet.whatnow.domains.image.exception.PromiseImageNotFoundException
 import com.depromeet.whatnow.domains.image.repository.PromiseImageRepository
 
 @Adapter
@@ -17,6 +18,15 @@ class PromiseImageAdapter(
     }
 
     fun findByImageKey(imageKey: String): PromiseImage {
-        return promiseImageRepository.findByImageKey(imageKey)
+        return promiseImageRepository.findByImageKey(imageKey) ?: run { throw PromiseImageNotFoundException.EXCEPTION }
+    }
+
+    fun deleteByImageKeyAndPromiseId(imageKey: String, promiseId: Long) {
+        promiseImageRepository.deleteByPromiseIdAndImageKey(promiseId, imageKey)
+    }
+
+    fun findByPromiseIdAndImageKey(promiseId: Long, imageKey: String): PromiseImage {
+        return promiseImageRepository.findByPromiseIdAndImageKey(promiseId, imageKey)
+            ?: run { throw PromiseImageNotFoundException.EXCEPTION }
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/UserImageAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/UserImageAdapter.kt
@@ -2,6 +2,7 @@ package com.depromeet.whatnow.domains.image.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
 import com.depromeet.whatnow.domains.image.domain.UserImage
+import com.depromeet.whatnow.domains.image.exception.UserImageNotFoundException
 import com.depromeet.whatnow.domains.image.repository.UserImageRepository
 
 @Adapter
@@ -10,5 +11,13 @@ class UserImageAdapter(
 ) {
     fun save(userImage: UserImage): UserImage {
         return userImageRepository.save(userImage)
+    }
+
+    fun findByUserIdAndImageKey(userId: Long, imageKey: String): UserImage {
+        return userImageRepository.findByUserIdAndImageKey(userId, imageKey) ?: run { throw UserImageNotFoundException.EXCEPTION }
+    }
+
+    fun deleteByImageKeyAndUserId(imageKey: String, userId: Long) {
+        return userImageRepository.deleteByImageKeyAndUserId(imageKey, userId)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/UserImage.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/domain/UserImage.kt
@@ -1,11 +1,18 @@
 package com.depromeet.whatnow.domains.image.domain
 
 import com.depromeet.whatnow.common.BaseTimeEntity
+import com.depromeet.whatnow.common.aop.event.Events
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+import com.depromeet.whatnow.domains.image.exception.UserImageOwnershipMismatchException
+import com.depromeet.whatnow.events.domainEvent.UserImageDeletedEvent
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.PostRemove
 import javax.persistence.Table
 
 @Entity
@@ -17,14 +24,28 @@ class UserImage(
 
     var imageKey: String,
 
+    @Enumerated(EnumType.STRING)
+    var fileExtension: ImageFileExtension,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_image_id")
     val id: Long? = null,
 ) : BaseTimeEntity() {
     companion object {
-        fun of(userId: Long, uri: String, imageKey: String): UserImage {
-            return UserImage(userId, uri, imageKey)
+        fun of(userId: Long, uri: String, imageKey: String, fileExtension: ImageFileExtension): UserImage {
+            return UserImage(userId, uri, imageKey, fileExtension)
         }
+    }
+
+    fun validateOwnership(userId: Long) {
+        if (this.userId != userId) {
+            throw UserImageOwnershipMismatchException.EXCEPTION
+        }
+    }
+
+    @PostRemove
+    fun deleteUserImage() {
+        Events.raise(UserImageDeletedEvent(userId, imageKey, fileExtension))
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/ImageErrorCode.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/ImageErrorCode.kt
@@ -8,13 +8,25 @@ import java.util.Objects
 
 enum class ImageErrorCode(val status: Int, val code: String, val reason: String) : BaseErrorCode {
     @ExplainError("트래킹이 시작 전에 이미지를 업로드하는 경우")
-    UPLOAD_BEFORE_TRACKING(BAD_REQUEST, "PICTURE_400_1", "트래킹 시작전에는 이미지를 업로드 할 수 없습니다."),
+    UPLOAD_BEFORE_TRACKING(BAD_REQUEST, "IMAGE_400_1", "트래킹 시작전에는 이미지를 업로드 할 수 없습니다."),
 
     @ExplainError("약속 참여에 취소한 유저가 업로드 하는 경우")
-    CANCELLED_USER_UPLOAD(BAD_REQUEST, "PICTURE_400_2", "약속 취소한 유저는 이미지를 업로드 할 수 없습니다."),
+    CANCELLED_USER_UPLOAD(BAD_REQUEST, "IMAGE_400_2", "약속 취소한 유저는 이미지를 업로드 할 수 없습니다."),
 
     @ExplainError("유저의 상태와 일치하는 코멘트가 아닐 경우")
-    INVALID_COMMENT_TYPE(BAD_REQUEST, "PICTURE_400_3", "유저의 상태와 일치하는 코멘트가 아닙니다."),
+    INVALID_COMMENT_TYPE(BAD_REQUEST, "IMAGE_400_3", "유저의 상태와 일치하는 코멘트가 아닙니다."),
+
+    @ExplainError("약속 이미지를 찾지 못했을 경우")
+    PROMISE_IMAGE_NOT_FOUND(BAD_REQUEST, "IMAGE_400_4", "약속 이미지를 찾지 못했습니다."),
+
+    @ExplainError("약속 이미지를 삭제하려는 유저와 이미지를 업로드한 유저가 다를 경우")
+    PROMISE_IMAGE_OWNERSHIP_MISMATCH(BAD_REQUEST, "IMAGE_400_5", "삭제하려는 유저가 약속 이미지를 업로드한 유저가 아닙니다."),
+
+    @ExplainError("유저 이미지를 찾지 못했을 경우")
+    USER_IMAGE_NOT_FOUND(BAD_REQUEST, "IMAGE_400_6", "유저 이미지를 찾지 못했습니다."),
+
+    @ExplainError("유저 이미지를 삭제하려는 유저와 이미지를 업로드한 유저가 다를 경우")
+    USER_IMAGE_OWNERSHIP_MISMATCH(BAD_REQUEST, "IMAGE_400_7", "삭제하려는 유저가 유저 이미지를 업로드한 유저가 아닙니다."),
     ;
 
     override val errorReason: ErrorReason

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/PromiseImageNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/PromiseImageNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.image.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class PromiseImageNotFoundException : WhatnowCodeException(
+    ImageErrorCode.PROMISE_IMAGE_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = PromiseImageNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/PromiseImageOwnershipMismatchException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/PromiseImageOwnershipMismatchException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.image.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class PromiseImageOwnershipMismatchException : WhatnowCodeException(
+    ImageErrorCode.PROMISE_IMAGE_OWNERSHIP_MISMATCH,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = PromiseImageOwnershipMismatchException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/UserImageNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/UserImageNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.image.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class UserImageNotFoundException : WhatnowCodeException(
+    ImageErrorCode.USER_IMAGE_NOT_FOUND,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = UserImageNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/UserImageOwnershipMismatchException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/exception/UserImageOwnershipMismatchException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.image.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class UserImageOwnershipMismatchException : WhatnowCodeException(
+    ImageErrorCode.USER_IMAGE_OWNERSHIP_MISMATCH,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = UserImageOwnershipMismatchException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/PromiseImageRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/PromiseImageRepository.kt
@@ -7,5 +7,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface PromiseImageRepository : JpaRepository<PromiseImage, Long> {
     fun findAllByPromiseId(promiseId: Long): List<PromiseImage>
-    fun findByImageKey(imageKey: String): PromiseImage
+    fun findByImageKey(imageKey: String): PromiseImage?
+    fun findByPromiseIdAndImageKey(promiseId: Long, imageKey: String): PromiseImage?
+    fun deleteByPromiseIdAndImageKey(promiseId: Long, imageKey: String)
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/UserImageRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/UserImageRepository.kt
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface UserImageRepository : JpaRepository<UserImage, Long>
+interface UserImageRepository : JpaRepository<UserImage, Long> {
+    fun findByUserIdAndImageKey(userId: Long, imageKey: String): UserImage?
+    fun deleteByImageKeyAndUserId(imageKey: String, userId: Long)
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/PromiseImageDeletedEvent.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/PromiseImageDeletedEvent.kt
@@ -1,0 +1,10 @@
+package com.depromeet.whatnow.events.domainEvent
+
+import com.depromeet.whatnow.common.aop.event.DomainEvent
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+
+class PromiseImageDeletedEvent(
+    val promiseId: Long,
+    val imageKey: String,
+    val imageFileExtension: ImageFileExtension,
+) : DomainEvent()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserImageDeletedEvent.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserImageDeletedEvent.kt
@@ -1,0 +1,10 @@
+package com.depromeet.whatnow.events.domainEvent
+
+import com.depromeet.whatnow.common.aop.event.DomainEvent
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+
+class UserImageDeletedEvent(
+    val userId: Long,
+    val imageKey: String,
+    val imageFileExtension: ImageFileExtension,
+) : DomainEvent()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/ImageDeletedEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/ImageDeletedEventHandler.kt
@@ -1,0 +1,40 @@
+package com.depromeet.whatnow.events.handler
+
+import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.config.s3.S3Service
+import com.depromeet.whatnow.events.domainEvent.PromiseImageDeletedEvent
+import com.depromeet.whatnow.events.domainEvent.UserImageDeletedEvent
+import mu.KLogger
+import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Handler
+class ImageDeletedEventHandler(
+    val s3Service: S3Service,
+) {
+    val logger: KLogger = KotlinLogging.logger {}
+
+    @Async
+    @TransactionalEventListener(classes = [UserImageDeletedEvent::class], phase = TransactionPhase.AFTER_COMMIT)
+    fun handleUserImageDeletedEvent(userImageDeletedEvent: UserImageDeletedEvent) {
+        val imageKey = userImageDeletedEvent.imageKey
+        val userId = userImageDeletedEvent.userId
+        val imageFileExtension = userImageDeletedEvent.imageFileExtension
+        logger.info { "UserImageDeletedEvent 이벤트 수신 imageKey=$imageKey, userId=$userId, fileExtension=$imageFileExtension" }
+
+        s3Service.deleteForUser(userId, imageKey, imageFileExtension)
+    }
+
+    @Async
+    @TransactionalEventListener(classes = [PromiseImageDeletedEvent::class], phase = TransactionPhase.AFTER_COMMIT)
+    fun handlePromiseImageDeletedEvent(promiseImageDeletedEvent: PromiseImageDeletedEvent) {
+        val imageKey = promiseImageDeletedEvent.imageKey
+        val promiseId = promiseImageDeletedEvent.promiseId
+        val imageFileExtension = promiseImageDeletedEvent.imageFileExtension
+        logger.info { "promiseImageDeletedEvent 이벤트 수신 imageKey=$imageKey, promiseId=$promiseId, fileExtension=$imageFileExtension" }
+
+        s3Service.deleteForPromise(promiseId, imageKey, imageFileExtension)
+    }
+}

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/adapter/PromisePromiseImageAdapterTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/adapter/PromisePromiseImageAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.depromeet.whatnow.domains.image.adapter
 
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImage
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.repository.PromiseImageRepository
@@ -22,7 +23,8 @@ class PromisePromiseImageAdapterTest {
 
     @Test
     fun `약속 이미지 저장 시 정상적으로 저장된다`() {
-        val promiseImage = PromiseImage.of(1, 1, "imageUri", "imageKey", PromiseImageCommentType.RUNNING)
+        // given
+        val promiseImage = PromiseImage.of(1, 1, "imageUri", "imageKey", ImageFileExtension.JPEG, PromiseImageCommentType.RUNNING)
         given(promiseImageRepository.save(Mockito.any(PromiseImage::class.java)))
             .willReturn(promiseImage)
 

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/service/PromiseImageDomainServiceTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/domains/image/service/PromiseImageDomainServiceTest.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.domains.image.service
 
 import com.depromeet.whatnow.common.vo.CoordinateVo
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.adapter.PromiseImageAdapter
 import com.depromeet.whatnow.domains.image.adapter.UserImageAdapter
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
@@ -50,12 +51,13 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.LATE,
         )
+        val fileExtension = ImageFileExtension.JPEG
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatCode {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", fileExtension, PromiseImageCommentType.RUNNING)
         }.doesNotThrowAnyException()
     }
 
@@ -68,12 +70,13 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.READY,
         )
+        val fileExtension = ImageFileExtension.JPEG
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", fileExtension, PromiseImageCommentType.RUNNING)
         }.isInstanceOf(UploadBeforeTrackingException::class.java)
     }
 
@@ -86,12 +89,13 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.CANCEL,
         )
+        val fileExtension = ImageFileExtension.JPEG
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", fileExtension, PromiseImageCommentType.RUNNING)
         }.isInstanceOf(CancelledUserUploadException::class.java)
     }
 
@@ -104,12 +108,13 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.LATE,
         )
+        val fileExtension = ImageFileExtension.JPEG
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.DID_YOU_COME)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", fileExtension, PromiseImageCommentType.DID_YOU_COME)
         }.isInstanceOf(InvalidCommentTypeException::class.java)
     }
 
@@ -122,12 +127,13 @@ class PromiseImageDomainServiceTest {
             userLocation = CoordinateVo(1.0, 1.0),
             promiseUserType = PromiseUserType.WAIT,
         )
+        val fileExtension = ImageFileExtension.JPEG
         given(promiseUserAdapter.findByPromiseIdAndUserId(anyLong(), anyLong()))
             .willReturn(promiseUser)
 
         // when, then
         Assertions.assertThatThrownBy {
-            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.WAIT_A_BIT)
+            imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", fileExtension, PromiseImageCommentType.WAIT_A_BIT)
         }.isInstanceOf(InvalidCommentTypeException::class.java)
     }
 }

--- a/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/events/handler/PromiseImageRegisterEventHandlerTest.kt
+++ b/Whatnow-Domain/src/test/kotlin/com/depromeet/whatnow/events/handler/PromiseImageRegisterEventHandlerTest.kt
@@ -2,6 +2,7 @@ package com.depromeet.whatnow.events.handler
 
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.DomainIntegrateSpringBootTest
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.image.domain.PromiseImageCommentType
 import com.depromeet.whatnow.domains.image.service.ImageDomainService
 import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
@@ -17,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 
 @DomainIntegrateSpringBootTest
-class PromisePromiseImageRegisterEventHandlerTest {
+class PromiseImageRegisterEventHandlerTest {
     @Autowired
     lateinit var imageDomainService: ImageDomainService
 
@@ -37,7 +38,7 @@ class PromisePromiseImageRegisterEventHandlerTest {
         given(promiseUserAdaptor.findByPromiseIdAndUserId(1, 1)).willReturn(promiseUser)
 
         // when
-        imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", PromiseImageCommentType.RUNNING)
+        imageDomainService.promiseImageUploadSuccess(1, 1, "imageKey", ImageFileExtension.JPEG, PromiseImageCommentType.RUNNING)
 
         // then
         then(imageRegisterEventHandler).should(Mockito.times(1)).handleRegisterPictureEvent(any())

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Service.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/config/s3/S3Service.kt
@@ -4,37 +4,48 @@ import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.Headers
 import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.DeleteObjectRequest
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.depromeet.whatnow.helper.SpringEnvironmentHelper
 import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
-class S3UploadPresignedUrlService(
+class S3Service(
     val amazonS3: AmazonS3,
     s3Properties: S3Properties,
     val springEnvironmentHelper: SpringEnvironmentHelper,
 ) {
     val s3Secret: S3Properties.S3Secret = s3Properties.s3
 
-    fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
-        val uuid = UUID.randomUUID().toString()
-        var fileName = getForPromiseFimeName(uuid, promiseId, fileExtension)
+    fun getPresignedUrlForPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
+        val imageKey = UUID.randomUUID().toString()
+        var fileName = getForPromiseFimeName(imageKey, promiseId, fileExtension)
         val generatePresignedUrlRequest =
             getGeneratePreSignedUrlRequest(s3Secret.bucket, fileName, fileExtension.uploadExtension)
 
         val generatePresignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest)
-        return ImageUrlDto(generatePresignedUrl.toString(), uuid)
+        return ImageUrlDto(generatePresignedUrl.toString(), imageKey)
     }
 
-    fun forUser(userId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
-        val uuid = UUID.randomUUID().toString()
-        var fileName = getForUserFimeName(uuid, userId, fileExtension)
+    fun getPresignedUrlForUser(userId: Long, fileExtension: ImageFileExtension): ImageUrlDto {
+        val imageKey = UUID.randomUUID().toString()
+        var fileName = getForUserFimeName(imageKey, userId, fileExtension)
         val generatePresignedUrlRequest =
             getGeneratePreSignedUrlRequest(s3Secret.bucket, fileName, fileExtension.uploadExtension)
 
         val generatePresignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest)
-        return ImageUrlDto(generatePresignedUrl.toString(), uuid)
+        return ImageUrlDto(generatePresignedUrl.toString(), imageKey)
+    }
+
+    fun deleteForPromise(promiseId: Long, imageKey: String, fileExtension: ImageFileExtension) {
+        var fileName = getForPromiseFimeName(imageKey, promiseId, fileExtension)
+        amazonS3.deleteObject(DeleteObjectRequest(s3Secret.bucket, fileName))
+    }
+
+    fun deleteForUser(userId: Long, imageKey: String, fileExtension: ImageFileExtension) {
+        var fileName = getForUserFimeName(imageKey, userId, fileExtension)
+        amazonS3.deleteObject(DeleteObjectRequest(s3Secret.bucket, fileName))
     }
 
     private fun getForPromiseFimeName(uuid: String, promiseId: Long, fileExtension: ImageFileExtension): String {

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3ServiceTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/config/s3/S3ServiceTest.kt
@@ -16,8 +16,8 @@ import org.springframework.core.env.Environment
 import kotlin.test.assertContains
 
 @ExtendWith(MockitoExtension::class)
-class S3UploadPresignedUrlServiceTest {
-    lateinit var s3UploadPresignedUrlService: S3UploadPresignedUrlService
+class S3ServiceTest {
+    lateinit var s3Service: S3Service
 
     var s3Properties: S3Properties = S3Properties(
         S3Properties.S3Secret(
@@ -44,7 +44,7 @@ class S3UploadPresignedUrlServiceTest {
 
     @BeforeEach
     fun setup() {
-        s3UploadPresignedUrlService = S3UploadPresignedUrlService(amazonS3, s3Properties, springEnvironmentHelper)
+        s3Service = S3Service(amazonS3, s3Properties, springEnvironmentHelper)
     }
 
     @Test
@@ -54,7 +54,7 @@ class S3UploadPresignedUrlServiceTest {
         val imageFIleExtension = ImageFileExtension.JPG
 
         // when
-        val presignedUrl = s3UploadPresignedUrlService.forPromise(promiseId, imageFIleExtension)
+        val presignedUrl = s3Service.getPresignedUrlForPromise(promiseId, imageFIleExtension)
 
         // then
         val resultUrl = "https://${s3Properties.s3.bucket}.${s3Properties.s3.endpoint.replace("https://", "")}/local/promise/$promiseId/${presignedUrl.key}.${imageFIleExtension.uploadExtension}"
@@ -69,7 +69,7 @@ class S3UploadPresignedUrlServiceTest {
         val imageFIleExtension = ImageFileExtension.JPG
 
         // when
-        val presignedUrl = s3UploadPresignedUrlService.forUser(userId, imageFIleExtension)
+        val presignedUrl = s3Service.getPresignedUrlForUser(userId, imageFIleExtension)
 
         // then
         val resultUrl = "https://${s3Properties.s3.bucket}.${s3Properties.s3.endpoint.replace("https://", "")}/local/user/$userId/${presignedUrl.key}.${imageFIleExtension.uploadExtension}"


### PR DESCRIPTION
## 개요
- close #98

## 작업사항
- 사진 삭제하는 기능을 추가하였습니다.
- promise 이미지는 서비스 내에서 사진 삭제 기능이 필요하여 API로 만들었습니다. (*사진참고)
![image](https://github.com/depromeet/Whatnow-Api/assets/64088250/982a311e-734f-4356-b5c4-7e5f820d61a9)
- user 이미지는 설정에서 유저 정보 변경시 삭제하기 위해 Service 메서드만 남겨두었습니다.
- 각 이미지 삭제시 `@PostRemove`를 통해 이벤트를 발행하여 핸들링합니다.

## 변경로직
- 삭제를 하기 위해서는 이미지의 fileExtension(확장자)가 필요한데, 각 이미지 엔티티에 필드가 없어서 추가하였습니다.
- `S3UploadPresignedUrlService`에서 `S3Service`로 이름 변경하였습니다