### PR TITLE
[DPMBE-106] user profile 수정 시 사용하지 않는 이미지는 삭제한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/image/usecase/GetPresignedUrlUseCase.kt
@@ -8,14 +8,14 @@ import com.depromeet.whatnow.config.security.SecurityUtils
 
 @UseCase
 class GetPresignedUrlUseCase(
-    val presignedUrlService: S3Service,
+    val s3Service: S3Service,
 ) {
     fun forPromise(promiseId: Long, fileExtension: ImageFileExtension): ImageUrlResponse {
-        return ImageUrlResponse.from(presignedUrlService.getPresignedUrlForPromise(promiseId, fileExtension))
+        return ImageUrlResponse.from(s3Service.getPresignedUrlForPromise(promiseId, fileExtension))
     }
 
     fun forUser(fileExtension: ImageFileExtension): ImageUrlResponse {
         val currentUserId = SecurityUtils.currentUserId
-        return ImageUrlResponse.from(presignedUrlService.getPresignedUrlForUser(currentUserId, fileExtension))
+        return ImageUrlResponse.from(s3Service.getPresignedUrlForUser(currentUserId, fileExtension))
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateProfileRequest.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateProfileRequest.kt
@@ -1,11 +1,8 @@
 package com.depromeet.whatnow.api.user.dto.request
 
-import com.depromeet.whatnow.config.s3.ImageFileExtension
-
 data class UpdateProfileRequest(
     val username: String,
     val profileImage: String,
     val isDefaultImg: Boolean,
     val imageKey: String,
-    val fileExtension: ImageFileExtension,
 )

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateProfileRequest.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/dto/request/UpdateProfileRequest.kt
@@ -1,6 +1,11 @@
 package com.depromeet.whatnow.api.user.dto.request
 
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+
 data class UpdateProfileRequest(
-    val profileImage: String,
     val username: String,
+    val profileImage: String,
+    val isDefaultImg: Boolean,
+    val imageKey: String,
+    val fileExtension: ImageFileExtension,
 )

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
@@ -29,7 +29,6 @@ class UpdateUserUseCase(
             updateProfileRequest.username,
             updateProfileRequest.isDefaultImg,
             updateProfileRequest.imageKey,
-            updateProfileRequest.fileExtension,
         )
             .toUserDetailVo()
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/user/usecase/UpdateUserUseCase.kt
@@ -23,7 +23,14 @@ class UpdateUserUseCase(
 
     fun updateProfile(updateProfileRequest: UpdateProfileRequest): UserDetailVo {
         val currentUserId: Long = SecurityUtils.currentUserId
-        return userDomainService.updateProfile(currentUserId, updateProfileRequest.profileImage, updateProfileRequest.username)
+        return userDomainService.updateProfile(
+            currentUserId,
+            updateProfileRequest.profileImage,
+            updateProfileRequest.username,
+            updateProfileRequest.isDefaultImg,
+            updateProfileRequest.imageKey,
+            updateProfileRequest.fileExtension,
+        )
             .toUserDetailVo()
     }
 }

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
@@ -29,6 +29,7 @@ const val RADIUS_WAIT_CONFIRM = 200
 
 const val IMAGE_DOMAIN = "https://image.whatnow.kr"
 const val ASSERT_IMAGE_DOMAIN = "https://image.whatnow.kr/assert"
+const val USER_DEFAULT_PROFILE_IMAGE = "https://image.whatnow.kr/assert/users/default.svg"
 
 const val REDIS_EXPIRE_EVENT_PATTERN = "__keyevent@*__:expired"
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/UserImageAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/adapter/UserImageAdapter.kt
@@ -11,4 +11,8 @@ class UserImageAdapter(
     fun save(userImage: UserImage): UserImage {
         return userImageRepository.save(userImage)
     }
+
+    fun findAllByUserId(userId: Long): List<UserImage> {
+        return userImageRepository.findAllByUserId(userId)
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/UserImageRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/image/repository/UserImageRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface UserImageRepository : JpaRepository<UserImage, Long>
+interface UserImageRepository : JpaRepository<UserImage, Long> {
+    fun findAllByUserId(userId: Long): List<UserImage>
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -7,6 +7,7 @@ import com.depromeet.whatnow.common.vo.UserInfoVo
 import com.depromeet.whatnow.consts.USER_DEFAULT_PROFILE_IMAGE
 import com.depromeet.whatnow.domains.user.exception.AlreadyDeletedUserException
 import com.depromeet.whatnow.domains.user.exception.ForbiddenUserException
+import com.depromeet.whatnow.events.domainEvent.UserProfileImageUpdatedEvent
 import com.depromeet.whatnow.events.domainEvent.UserSignUpEvent
 import java.time.LocalDateTime
 import javax.persistence.Column
@@ -92,13 +93,13 @@ class User(
         fcmNotification = FcmNotificationVo.updateToken(fcmNotification, fcmToken)
     }
 
-    fun updateProfile(profileImage: String, username: String, isDefaultImage: Boolean) {
+    fun updateProfile(profileImage: String, username: String, isDefaultImage: Boolean, imageKey: String) {
         this.nickname = username
         this.isDefaultImg = isDefaultImage
-        this.profileImg = if (isDefaultImage) {
-            USER_DEFAULT_PROFILE_IMAGE
-        } else {
-            profileImage
+        this.profileImg = profileImage.takeIf { !isDefaultImage } ?: USER_DEFAULT_PROFILE_IMAGE
+
+        if (!isDefaultImage) {
+            Events.raise(UserProfileImageUpdatedEvent(this.id!!, imageKey))
         }
     }
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/domain/User.kt
@@ -4,6 +4,7 @@ import com.depromeet.whatnow.common.BaseTimeEntity
 import com.depromeet.whatnow.common.aop.event.Events
 import com.depromeet.whatnow.common.vo.UserDetailVo
 import com.depromeet.whatnow.common.vo.UserInfoVo
+import com.depromeet.whatnow.consts.USER_DEFAULT_PROFILE_IMAGE
 import com.depromeet.whatnow.domains.user.exception.AlreadyDeletedUserException
 import com.depromeet.whatnow.domains.user.exception.ForbiddenUserException
 import com.depromeet.whatnow.events.domainEvent.UserSignUpEvent
@@ -91,12 +92,14 @@ class User(
         fcmNotification = FcmNotificationVo.updateToken(fcmNotification, fcmToken)
     }
 
-    fun updateProfile(profileImage: String, username: String) {
-        if (profileImage != profileImg) {
-            isDefaultImg = false
+    fun updateProfile(profileImage: String, username: String, isDefaultImage: Boolean) {
+        this.nickname = username
+        this.isDefaultImg = isDefaultImage
+        this.profileImg = if (isDefaultImage) {
+            USER_DEFAULT_PROFILE_IMAGE
+        } else {
+            profileImage
         }
-        profileImg = profileImage
-        nickname = username
     }
 
     fun toUserInfoVo(): UserInfoVo {

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -1,11 +1,14 @@
 package com.depromeet.whatnow.domains.user.service
 
 import com.depromeet.whatnow.annotation.DomainService
+import com.depromeet.whatnow.common.aop.event.Events
+import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
 import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.exception.AlreadySignUpUserException
+import com.depromeet.whatnow.events.domainEvent.UserProfileImageUpdatedEvent
 import org.springframework.transaction.annotation.Transactional
 
 @DomainService
@@ -103,9 +106,13 @@ class UserDomainService(
     }
 
     @Transactional
-    fun updateProfile(currentUserId: Long, profileImage: String, username: String): User {
+    fun updateProfile(currentUserId: Long, profileImage: String, username: String, isDefaultImage: Boolean, imageKey: String, fileExtension: ImageFileExtension): User {
         val user = userAdapter.queryUser(currentUserId)
-        user.updateProfile(profileImage, username)
+        user.updateProfile(profileImage, username, isDefaultImage)
+
+        if (!isDefaultImage) {
+            Events.raise(UserProfileImageUpdatedEvent(currentUserId, imageKey, fileExtension))
+        }
         return user
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -1,13 +1,11 @@
 package com.depromeet.whatnow.domains.user.service
 
 import com.depromeet.whatnow.annotation.DomainService
-import com.depromeet.whatnow.common.aop.event.Events
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
 import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
 import com.depromeet.whatnow.domains.user.domain.User
 import com.depromeet.whatnow.domains.user.exception.AlreadySignUpUserException
-import com.depromeet.whatnow.events.domainEvent.UserProfileImageUpdatedEvent
 import org.springframework.transaction.annotation.Transactional
 
 @DomainService

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -2,7 +2,6 @@ package com.depromeet.whatnow.domains.user.service
 
 import com.depromeet.whatnow.annotation.DomainService
 import com.depromeet.whatnow.common.aop.event.Events
-import com.depromeet.whatnow.config.s3.ImageFileExtension
 import com.depromeet.whatnow.domains.user.adapter.UserAdapter
 import com.depromeet.whatnow.domains.user.domain.FcmNotificationVo
 import com.depromeet.whatnow.domains.user.domain.OauthInfo
@@ -106,12 +105,12 @@ class UserDomainService(
     }
 
     @Transactional
-    fun updateProfile(currentUserId: Long, profileImage: String, username: String, isDefaultImage: Boolean, imageKey: String, fileExtension: ImageFileExtension): User {
+    fun updateProfile(currentUserId: Long, profileImage: String, username: String, isDefaultImage: Boolean, imageKey: String): User {
         val user = userAdapter.queryUser(currentUserId)
         user.updateProfile(profileImage, username, isDefaultImage)
 
         if (!isDefaultImage) {
-            Events.raise(UserProfileImageUpdatedEvent(currentUserId, imageKey, fileExtension))
+            Events.raise(UserProfileImageUpdatedEvent(currentUserId, imageKey))
         }
         return user
     }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/user/service/UserDomainService.kt
@@ -107,11 +107,7 @@ class UserDomainService(
     @Transactional
     fun updateProfile(currentUserId: Long, profileImage: String, username: String, isDefaultImage: Boolean, imageKey: String): User {
         val user = userAdapter.queryUser(currentUserId)
-        user.updateProfile(profileImage, username, isDefaultImage)
-
-        if (!isDefaultImage) {
-            Events.raise(UserProfileImageUpdatedEvent(currentUserId, imageKey))
-        }
+        user.updateProfile(profileImage, username, isDefaultImage, imageKey)
         return user
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserProfileImageUpdatedEvent.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserProfileImageUpdatedEvent.kt
@@ -1,10 +1,8 @@
 package com.depromeet.whatnow.events.domainEvent
 
 import com.depromeet.whatnow.common.aop.event.DomainEvent
-import com.depromeet.whatnow.config.s3.ImageFileExtension
 
 class UserProfileImageUpdatedEvent(
     val userId: Long,
     val imageKey: String,
-    val fileExtension: ImageFileExtension,
 ) : DomainEvent()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserProfileImageUpdatedEvent.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/domainEvent/UserProfileImageUpdatedEvent.kt
@@ -1,0 +1,10 @@
+package com.depromeet.whatnow.events.domainEvent
+
+import com.depromeet.whatnow.common.aop.event.DomainEvent
+import com.depromeet.whatnow.config.s3.ImageFileExtension
+
+class UserProfileImageUpdatedEvent(
+    val userId: Long,
+    val imageKey: String,
+    val fileExtension: ImageFileExtension,
+) : DomainEvent()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.events.handler
 
 import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.config.s3.S3Service
 import com.depromeet.whatnow.domains.image.adapter.UserImageAdapter
 import com.depromeet.whatnow.events.domainEvent.UserProfileImageUpdatedEvent
 import org.springframework.scheduling.annotation.Async
@@ -9,7 +10,7 @@ import org.springframework.transaction.event.TransactionalEventListener
 
 @Handler
 class UserProfileImageUpdatedEventHandler(
-//    val s3Service: S3Service,
+    val s3Service: S3Service,
     val userImageAdapter: UserImageAdapter,
 ) {
     @Async
@@ -18,11 +19,10 @@ class UserProfileImageUpdatedEventHandler(
         val userId = userProfileImageUpdatedEvent.userId
         val imageKey = userProfileImageUpdatedEvent.imageKey
 
-        // TODO [DPMBE-76] 사진 삭제기능 업데이트 시 주석 해제
-        val userImages = userImageAdapter.findAllByUserId(userId)
+        userImageAdapter.findAllByUserId(userId)
             .filter { it.imageKey != imageKey }
             .map {
-//                s3Service.deleteForUser(userId, it.imageKey, it.fileExtension)
+                s3Service.deleteForUser(userId, it.imageKey, it.fileExtension)
             }
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
@@ -1,0 +1,29 @@
+package com.depromeet.whatnow.events.handler
+
+import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.domains.image.adapter.UserImageAdapter
+import com.depromeet.whatnow.events.domainEvent.UserProfileImageUpdatedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Handler
+class UserProfileImageUpdatedEventHandler(
+//    val s3Service: S3Service,
+    val userImageAdapter: UserImageAdapter,
+) {
+    @Async
+    @TransactionalEventListener(classes = [UserProfileImageUpdatedEvent::class], phase = TransactionPhase.AFTER_COMMIT)
+    fun handleRegisterUserEvent(userProfileImageUpdatedEvent: UserProfileImageUpdatedEvent) {
+        val userId = userProfileImageUpdatedEvent.userId
+        val imageKey = userProfileImageUpdatedEvent.imageKey
+        val fileExtension = userProfileImageUpdatedEvent.fileExtension
+
+        // TODO [DPMBE-76] 사진 삭제기능 업데이트 시 주석 해제
+        val userImages = userImageAdapter.findAllByUserId(userId)
+            .filter { it.imageKey != imageKey }
+            .map {
+//                s3Service.deleteForUser(userId, it.imageKey, it.fileExtension)
+            }
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/UserProfileImageUpdatedEventHandler.kt
@@ -17,7 +17,6 @@ class UserProfileImageUpdatedEventHandler(
     fun handleRegisterUserEvent(userProfileImageUpdatedEvent: UserProfileImageUpdatedEvent) {
         val userId = userProfileImageUpdatedEvent.userId
         val imageKey = userProfileImageUpdatedEvent.imageKey
-        val fileExtension = userProfileImageUpdatedEvent.fileExtension
 
         // TODO [DPMBE-76] 사진 삭제기능 업데이트 시 주석 해제
         val userImages = userImageAdapter.findAllByUserId(userId)


### PR DESCRIPTION
## 개요
- close #160 

## 작업사항
- user profile 업데이트 시 기존 사용하던 이미지 파일은 삭제하는 로직을 추가하였습니다.
- #157 이슈 머지되면 주석 제거 하겠습니다

## 변경로직
- 기존 userProfileUpdate시에 isDefaultImage(boolean)을 받지 않아 받도록 변경하였고,
기존 프로필이 default가 아닐때는 이전 파일을 지우도록 구현하였습니다