### PR TITLE
[DPMBE-104] 약속 조회 기능에 주소를 추가및 정렬 기준 추가한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -46,8 +46,7 @@ class PromiseController(
     @GetMapping("/promises/users")
     fun findPromiseByUserAndYearMonth(@RequestParam(value = "year-month") yearMonth: YearMonth): List<PromiseFindDto> {
         val result = promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
-        // endTime 최신순 정렬
-        return result.sortedBy { it.endTime }
+        return result
     }
 
     @Operation(summary = "약속 모음집 상세", description = "D3. 지난(AFTER) 약속 상세 조회 (날짜(월,일), 약속 사진 url, 타임오버 캡쳐, 만난 사람(프로필 사진 Url,  이름, wait/late 여부, interaction 종륲별 카운트), 하이라이트 기록 최대 3개")
@@ -60,6 +59,12 @@ class PromiseController(
     @GetMapping("/promises/{promise-id}/active")
     fun findPromiseActive(@PathVariable(value = "promise-id") promiseId: Long): Boolean {
         return promiseReadUseCase.findPromiseActive(promiseId)
+    }
+
+    @Operation(summary = "promiseId 로 약속 조회", description = "promiseId 로 약속 조회")
+    @GetMapping("/promises/{promise-id}")
+    fun findByPromiseId(@PathVariable(value = "promise-id") promiseId: Long): PromiseFindDto {
+        return promiseReadUseCase.findByPromiseId(promiseId)
     }
 
     @Operation(summary = "약속(promise) 생성", description = "약속을 생성합니다.")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -45,7 +45,9 @@ class PromiseController(
     @Operation(summary = "월단위 약속 조회", description = "유저의 월간 약속 조회 (단, 예정된 약속과 지난 약속을 구분없이 조회), year-month 파라미터는 2021-01 이 형식입니다.")
     @GetMapping("/promises/users")
     fun findPromiseByUserAndYearMonth(@RequestParam(value = "year-month") yearMonth: YearMonth): List<PromiseFindDto> {
-        return promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
+        val result = promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
+        // endTime 최신순 정렬
+        return result.sortedBy { it.endTime }
     }
 
     @Operation(summary = "약속 모음집 상세", description = "D3. 지난(AFTER) 약속 상세 조회 (날짜(월,일), 약속 사진 url, 타임오버 캡쳐, 만난 사람(프로필 사진 Url,  이름, wait/late 여부, interaction 종륲별 카운트), 하이라이트 기록 최대 3개")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -42,11 +42,13 @@ class PromiseController(
         return promiseReadUseCase.findPromiseByUserIdSeparatedType()
     }
 
-    @Operation(summary = "월단위 약속 조회", description = "유저의 월간 약속 조회 (단, 예정된 약속과 지난 약속을 구분없이 조회), year-month 파라미터는 2021-01 이 형식입니다.")
+    @Operation(
+        summary = "월단위 약속 조회",
+        description = "유저의 월간 약속 조회 (단, 예정된 약속과 지난 약속을 구분없이 조회), year-month 파라미터는 2021-01 이 형식입니다.",
+    )
     @GetMapping("/promises/users")
     fun findPromiseByUserAndYearMonth(@RequestParam(value = "year-month") yearMonth: YearMonth): List<PromiseFindDto> {
-        val result = promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
-        return result
+        return promiseReadUseCase.findPromiseByUserIdYearMonth(yearMonth)
     }
 
     @Operation(summary = "약속 모음집 상세", description = "D3. 지난(AFTER) 약속 상세 조회 (날짜(월,일), 약속 사진 url, 타임오버 캡쳐, 만난 사람(프로필 사진 Url,  이름, wait/late 여부, interaction 종륲별 카운트), 하이라이트 기록 최대 3개")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
@@ -12,7 +12,7 @@ data class PromiseDetailDto(
     val promiseImageUrls: List<String>?,
     val timeOverLocations: List<LocationCapture>,
     // TODO : highlight 기능 추가시 함께 추가할게요. ( 최대 3개 제한 )
-//    val highlights: List<NotificationDto>,
+// x   val highlights: List<NotificationDto>,
 ) {
     companion object {
         fun of(

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
@@ -9,7 +9,7 @@ data class PromiseDetailDto(
     val address: String,
     val coordinateVo: CoordinateVo,
     val title: String,
-    val date: LocalDateTime,
+    val endTime: LocalDateTime,
     // 유저의 마지막 위치 리스트
     val promiseUsers: List<PromiseUserInfoVo>,
     // TODO : 약속 기록 사진 기능 추가시 함께 추가할게요.
@@ -30,7 +30,7 @@ data class PromiseDetailDto(
                 address = promise.meetPlace!!.address,
                 coordinateVo = promise.meetPlace!!.coordinate,
                 title = promise.title,
-                date = promise.endTime,
+                endTime = promise.endTime,
                 promiseUsers = promiseUsers,
                 promiseImageUrls = promiseImageUrls,
                 timeOverLocations = timeOverLocations,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseDetailDto.kt
@@ -1,9 +1,13 @@
 package com.depromeet.whatnow.api.promise.dto
 
+import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.domains.promise.domain.Promise
 import java.time.LocalDateTime
 
 data class PromiseDetailDto(
+    val promiseId: Long,
+    val address: String,
+    val coordinateVo: CoordinateVo,
     val title: String,
     val date: LocalDateTime,
     // 유저의 마지막 위치 리스트
@@ -22,6 +26,9 @@ data class PromiseDetailDto(
             timeOverLocations: List<LocationCapture>,
         ): PromiseDetailDto {
             return PromiseDetailDto(
+                promiseId = promise.id!!,
+                address = promise.meetPlace!!.address,
+                coordinateVo = promise.meetPlace!!.coordinate,
                 title = promise.title,
                 date = promise.endTime,
                 promiseUsers = promiseUsers,

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseFindDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseFindDto.kt
@@ -1,12 +1,15 @@
 package com.depromeet.whatnow.api.promise.dto
 
+import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.common.vo.UserInfoVo
 import com.depromeet.whatnow.domains.promise.domain.Promise
 import java.time.LocalDateTime
 
 data class PromiseFindDto(
-    val title: String,
+    val promiseId: Long,
     val address: String,
+    val coordinateVo: CoordinateVo,
+    val title: String,
     val endTime: LocalDateTime,
     val users: List<UserInfoVo> = mutableListOf(),
 ) {
@@ -15,10 +18,12 @@ data class PromiseFindDto(
             val userValues = mutableListOf<UserInfoVo>()
             userValues.addAll(users)
             return PromiseFindDto(
-                promise.title,
-                promise.meetPlace!!.address,
-                promise.endTime,
-                userValues,
+                promiseId = promise.id!!,
+                address = promise.meetPlace!!.address,
+                coordinateVo = promise.meetPlace!!.coordinate,
+                title = promise.title,
+                endTime = promise.endTime,
+                users = userValues,
             )
         }
     }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -89,7 +89,7 @@ class PromiseReadUseCase(
                     promise = promise,
                     users = participants,
                 )
-            }.sortedBy { it.endTime }
+            }.sortedByDescending { it.endTime }
     }
 
     fun findPromiseDetailByStatus(promiseType: PromiseType): List<PromiseDetailDto> {
@@ -110,7 +110,7 @@ class PromiseReadUseCase(
                 val interactions =
                     interactionAdapter.queryAllInteraction(promiseUser.promiseId, promiseUser.userId)
                         .map { InteractionDto.from(it) }
-                        .sortedByDescending { interactionDto -> interactionDto.count }
+                        .sortedByDescendingDescending { interactionDto -> interactionDto.count }
                 user?.let {
                     PromiseUserInfoVo.of(it, promiseUser.promiseUserType!!, interactions)
                 }
@@ -132,7 +132,7 @@ class PromiseReadUseCase(
             )
         }
 
-        return result.sortedBy { it.endTime }
+        return result.sortedByDescending { it.endTime }
     }
 
     fun findPromiseActive(promiseId: Long): Boolean {
@@ -150,7 +150,7 @@ class PromiseReadUseCase(
 
     private fun findPromisesByUserId(userId: Long): List<Promise> {
         val promiseUsers = promiseUserAdaptor.findByUserId(userId)
-        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }.sortedBy { it.endTime }
+        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }.sortedByDescending { it.endTime }
     }
 
     fun findByPromiseId(promiseId: Long): PromiseFindDto {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -110,7 +110,7 @@ class PromiseReadUseCase(
                 val interactions =
                     interactionAdapter.queryAllInteraction(promiseUser.promiseId, promiseUser.userId)
                         .map { InteractionDto.from(it) }
-                        .sortedByDescendingDescending { interactionDto -> interactionDto.count }
+                        .sortedByDescending { interactionDto -> interactionDto.count }
                 user?.let {
                     PromiseUserInfoVo.of(it, promiseUser.promiseUserType!!, interactions)
                 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -85,10 +85,8 @@ class PromiseReadUseCase(
             .map { promise ->
                 // 약속에 참여한 유저들
                 val participants = getParticipantUserInfo(promiseUserAdaptor.findByPromiseId(promise.id!!))
-                PromiseFindDto(
-                    title = promise.title,
-                    address = promise.meetPlace!!.address,
-                    endTime = promise.endTime,
+                PromiseFindDto.of(
+                    promise = promise,
                     users = participants,
                 )
             }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -18,6 +18,7 @@ import com.depromeet.whatnow.domains.user.adapter.UserAdapter
 import com.depromeet.whatnow.domains.user.repository.UserRepository
 import java.time.LocalDateTime
 import java.time.YearMonth
+import kotlin.collections.Map.Entry
 
 @UseCase
 class PromiseReadUseCase(
@@ -34,18 +35,13 @@ class PromiseReadUseCase(
      */
     fun findPromiseByUserIdSeparatedType(): Map<PromiseType, MutableList<PromiseFindDto>> {
         val userId: Long = SecurityUtils.currentUserId
-
-        // 내가 참여한 약속들(약속유저)
         val promiseUsers = promiseUserAdaptor.findByUserId(userId)
         val promiseIds = promiseUsers.map { it.promiseId }
-        //  내가 참여한 약속들
         val promises = promiseAdaptor.queryPromises(promiseIds).associateBy { it.id }
-        // 내가 참여한 약속들에 참여한 친구들
         val promiseUsersByPromiseId = promiseUserAdaptor.findByPromiseIds(promiseIds).groupBy { it.promiseId }
         val promiseSplitByPromiseTypeDto = mutableMapOf<PromiseType, MutableList<PromiseFindDto>>()
 
-        for (promiseUser in promiseUsers) {
-            // 약속 하나씩
+        promiseUsers.forEach() { promiseUser ->
             val promise = promises[promiseUser.promiseId]
             val eachPromiseUsers = promiseUsersByPromiseId[promiseUser.promiseId] ?: emptyList()
             val participant = getParticipantUserInfo(eachPromiseUsers)
@@ -60,16 +56,20 @@ class PromiseReadUseCase(
                 }
 
                 PromiseType.DELETED -> {
-                    // TODO
-                    // Do nothing for deleted promises.
+                    return@forEach
                 }
                 null -> {
-                    // TODO
+                    return@forEach
                 }
                 else -> {
-                    // TODO
+                    return@forEach
                 }
             }
+
+            val action: (Entry<PromiseType, MutableList<PromiseFindDto>>) -> Unit = { (promiseType, promiseFindDtos) ->
+                promiseFindDtos.sortBy { it.endTime }
+            }
+            promiseSplitByPromiseTypeDto.forEach(action)
         }
         return promiseSplitByPromiseTypeDto
     }
@@ -89,18 +89,7 @@ class PromiseReadUseCase(
                     promise = promise,
                     users = participants,
                 )
-            }
-    }
-
-    fun findPromisesByUserId(userId: Long): List<Promise> {
-        val promiseUsers = promiseUserAdaptor.findByUserId(userId)
-        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }
-    }
-
-    fun getParticipantUserInfo(promiseUsers: List<PromiseUser>): List<UserInfoVo> {
-        val userIds = promiseUsers.map { it.userId }
-        val users = userRepository.findAllById(userIds)
-        return users.mapNotNull { UserInfoVo.from(it) }
+            }.sortedBy { it.endTime }
     }
 
     fun findPromiseDetailByStatus(promiseType: PromiseType): List<PromiseDetailDto> {
@@ -134,16 +123,16 @@ class PromiseReadUseCase(
             }
 
             result.add(
-                PromiseDetailDto(
-                    title = promise.title,
-                    date = promise.endTime,
+                PromiseDetailDto.of(
+                    promise = promise,
                     promiseUsers = promiseUserInfoVos,
-                    promiseImageUrls = null,
                     timeOverLocations = timeOverLocations,
+                    promiseImageUrls = mutableListOf(),
                 ),
             )
         }
-        return result
+
+        return result.sortedBy { it.endTime }
     }
 
     fun findPromiseActive(promiseId: Long): Boolean {
@@ -152,5 +141,15 @@ class PromiseReadUseCase(
         val now = LocalDateTime.now()
         val endTime = promise.endTime
         return now.isAfter(endTime.minusHours(1)) && now.isBefore(endTime.plusMinutes(30))
+    }
+    private fun getParticipantUserInfo(promiseUsers: List<PromiseUser>): List<UserInfoVo> {
+        val userIds = promiseUsers.map { it.userId }
+        val users = userRepository.findAllById(userIds)
+        return users.mapNotNull { UserInfoVo.from(it) }
+    }
+
+    private fun findPromisesByUserId(userId: Long): List<Promise> {
+        val promiseUsers = promiseUserAdaptor.findByUserId(userId)
+        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }.sortedBy { it.endTime }
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -152,4 +152,11 @@ class PromiseReadUseCase(
         val promiseUsers = promiseUserAdaptor.findByUserId(userId)
         return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }.sortedBy { it.endTime }
     }
+
+    fun findByPromiseId(promiseId: Long): PromiseFindDto {
+        val promise = promiseAdaptor.queryPromise(promiseId)
+        val promiseUsers = promiseUserAdaptor.findByPromiseId(promiseId)
+        val participants = getParticipantUserInfo(promiseUsers)
+        return PromiseFindDto.of(promise, participants)
+    }
 }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
@@ -1,5 +1,7 @@
 package com.depromeet.whatnow.api.promise.usecase
 
+import com.depromeet.whatnow.common.vo.CoordinateVo
+import com.depromeet.whatnow.common.vo.PlaceVo
 import com.depromeet.whatnow.domains.interaction.adapter.InteractionAdapter
 import com.depromeet.whatnow.domains.interaction.domain.Interaction
 import com.depromeet.whatnow.domains.interaction.domain.InteractionType
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -74,12 +77,13 @@ class PromiseReadUseCaseTest {
         val promiseTime2 = LocalDateTime.now()
         val promiseUsers = listOf(
             PromiseUser(userId = 1, promiseId = 1, promiseUserType = WAIT),
-//            PromiseUser(userId = 2, promiseId = 1, promiseUserType = LATE),
             PromiseUser(userId = 1, promiseId = 2, promiseUserType = WAIT),
         )
         val promises = listOf(
-            Promise(id = 1, title = "Promise 1", endTime = promiseTime1, mainUserId = 1),
-            Promise(id = 2, title = "Promise 2", endTime = promiseTime2, mainUserId = 2L),
+            Promise(id = 1, title = "Promise 1", endTime = promiseTime1, mainUserId = 1L, meetPlace = PlaceVo(
+                CoordinateVo(352.1,123.2), "서울시 강남구"), promiseType = PromiseType.BEFORE),
+            Promise(id = 2, title = "Promise 2", endTime = promiseTime2, mainUserId = 2L, meetPlace = PlaceVo(
+                CoordinateVo(352.1,123.2), "서울시 강남구"), promiseType = PromiseType.DELETED),
         )
         val users = listOf(
             User(
@@ -106,10 +110,10 @@ class PromiseReadUseCaseTest {
             Interaction(InteractionType.STEP, 1, 1, 2934),
         )
 
-        Mockito.`when`(promiseUserAdaptor.findByUserId(userId)).thenReturn(promiseUsers)
-        Mockito.`when`(promiseAdaptor.queryPromises(listOf(1, 2))).thenReturn(promises)
-        Mockito.`when`(userAdapter.queryUsers(listOf(1))).thenReturn(users)
-        Mockito.`when`(interactionAdapter.queryAllInteraction(1, 1)).thenReturn(interactions)
+        `when`(promiseUserAdaptor.findByUserId(userId)).thenReturn(promiseUsers)
+        `when`(promiseAdaptor.queryPromises(listOf(1, 2))).thenReturn(promises)
+        `when`(userAdapter.queryUsers(listOf(1))).thenReturn(users)
+        `when`(interactionAdapter.queryAllInteraction(1, 1)).thenReturn(interactions)
 
         // When
         val result = promiseReadUseCase.findPromiseDetailByStatus(PromiseType.BEFORE)
@@ -118,11 +122,11 @@ class PromiseReadUseCaseTest {
         Assertions.assertEquals(2, result.size)
 
         Assertions.assertEquals("Promise 1", result[0].title)
-        Assertions.assertEquals(promiseTime1, result[0].date)
+        Assertions.assertEquals(promiseTime1, result[0].endTime)
         Assertions.assertEquals(1, result[0].promiseUsers.size)
 
         Assertions.assertEquals("Promise 2", result[1].title)
-        Assertions.assertEquals(promiseTime2, result[1].date)
+        Assertions.assertEquals(promiseTime2, result[1].endTime)
         Assertions.assertEquals(1, result[1].promiseUsers.size)
 
         Assertions.assertEquals(2934, result[0].promiseUsers[0].interactions[0].count)

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
@@ -85,7 +85,7 @@ class PromiseReadUseCaseTest {
                 endTime = promiseTime1,
                 mainUserId = 1L,
                 meetPlace = PlaceVo(
-                    CoordinateVo(352.1, 123.2),
+                    CoordinateVo(352.1, 167.2),
                     "서울시 강남구",
                 ),
                 promiseType = PromiseType.BEFORE,
@@ -96,8 +96,8 @@ class PromiseReadUseCaseTest {
                 endTime = promiseTime2,
                 mainUserId = 2L,
                 meetPlace = PlaceVo(
-                    CoordinateVo(352.1, 123.2),
-                    "서울시 강남구",
+                    CoordinateVo(123.4, 234.2),
+                    "전라북도 남원시",
                 ),
                 promiseType = PromiseType.DELETED,
             ),
@@ -120,17 +120,22 @@ class PromiseReadUseCaseTest {
                 id = 2,
             ),
         )
-        val interactions = listOf(
+        val interactionsPromise1 = listOf(
             Interaction(InteractionType.HEART, 1, 1, 242),
             Interaction(InteractionType.MUSIC, 1, 1, 1234),
-            Interaction(InteractionType.POOP, 1, 1, 12),
-            Interaction(InteractionType.STEP, 1, 1, 2934),
+        )
+
+        val interactionsPromise2 = listOf(
+            Interaction(InteractionType.POOP, 1, 2, 12),
+            Interaction(InteractionType.STEP, 1, 2, 2934),
         )
 
         `when`(promiseUserAdaptor.findByUserId(userId)).thenReturn(promiseUsers)
         `when`(promiseAdaptor.queryPromises(listOf(1, 2))).thenReturn(promises)
         `when`(userAdapter.queryUsers(listOf(1))).thenReturn(users)
-        `when`(interactionAdapter.queryAllInteraction(1, 1)).thenReturn(interactions)
+//        `when`(interactionAdapter.queryAllInteraction(1, 1)).thenReturn(interactions)
+        `when`(interactionAdapter.queryAllInteraction(1, 1)).thenReturn(interactionsPromise1)
+        `when`(interactionAdapter.queryAllInteraction(2, 1)).thenReturn(interactionsPromise2)
 
         // When
         val result = promiseReadUseCase.findPromiseDetailByStatus(PromiseType.BEFORE)
@@ -138,15 +143,17 @@ class PromiseReadUseCaseTest {
         // Then
         Assertions.assertEquals(2, result.size)
 
-        Assertions.assertEquals("Promise 1", result[0].title)
-        Assertions.assertEquals(promiseTime1, result[0].endTime)
-        Assertions.assertEquals(1, result[0].promiseUsers.size)
-
-        Assertions.assertEquals("Promise 2", result[1].title)
-        Assertions.assertEquals(promiseTime2, result[1].endTime)
+        Assertions.assertEquals("Promise 2", result[0].title)
+        Assertions.assertEquals(promiseTime1, result[1].endTime)
         Assertions.assertEquals(1, result[1].promiseUsers.size)
 
+        Assertions.assertEquals("Promise 1", result[1].title)
+        Assertions.assertEquals(promiseTime2, result[0].endTime)
+        Assertions.assertEquals(1, result[0].promiseUsers.size)
+
+        // 약속 1번
+        Assertions.assertEquals(1234, result[1].promiseUsers[0].interactions[0].count)
+        // 약속 2번
         Assertions.assertEquals(2934, result[0].promiseUsers[0].interactions[0].count)
-        Assertions.assertEquals(1234, result[0].promiseUsers[0].interactions[1].count)
     }
 }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.junit.jupiter.MockitoExtension
@@ -80,10 +79,28 @@ class PromiseReadUseCaseTest {
             PromiseUser(userId = 1, promiseId = 2, promiseUserType = WAIT),
         )
         val promises = listOf(
-            Promise(id = 1, title = "Promise 1", endTime = promiseTime1, mainUserId = 1L, meetPlace = PlaceVo(
-                CoordinateVo(352.1,123.2), "서울시 강남구"), promiseType = PromiseType.BEFORE),
-            Promise(id = 2, title = "Promise 2", endTime = promiseTime2, mainUserId = 2L, meetPlace = PlaceVo(
-                CoordinateVo(352.1,123.2), "서울시 강남구"), promiseType = PromiseType.DELETED),
+            Promise(
+                id = 1,
+                title = "Promise 1",
+                endTime = promiseTime1,
+                mainUserId = 1L,
+                meetPlace = PlaceVo(
+                    CoordinateVo(352.1, 123.2),
+                    "서울시 강남구",
+                ),
+                promiseType = PromiseType.BEFORE,
+            ),
+            Promise(
+                id = 2,
+                title = "Promise 2",
+                endTime = promiseTime2,
+                mainUserId = 2L,
+                meetPlace = PlaceVo(
+                    CoordinateVo(352.1, 123.2),
+                    "서울시 강남구",
+                ),
+                promiseType = PromiseType.DELETED,
+            ),
         )
         val users = listOf(
             User(


### PR DESCRIPTION
## 개요
- close #156

## 작업사항
- promiseFindDto, promiseDetailDto 에 promiseId ,address 와 위경도 데이터를 추가했습니다.
- 앱이 꺼지고 다시 켜진 다음에 단건 조회해야할 니즈가 있다고 전달 받아 단건 조회를 만들었습니다.
```
    companion object {
        fun of(promise: Promise, users: List<UserInfoVo>): PromiseFindDto {

            )
        }
```
이렇게 해놓으니까 변경이 편하네요

## 변경로직
- 모든 promise 조회시 endTime(약속시간) 최신순 기준으로 정렬했습니다.