### PR TITLE
[DPMBE-114] 약속 정렬 순서를 오래된 순으로 변경한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -69,8 +69,8 @@ class PromiseReadUseCase(
             }
 
             val action: (Entry<PromiseType, MutableList<PromiseFindDto>>) -> Unit = { (promiseType, promiseFindDtos) ->
-                //promiseType == BEFORE 인 것만 정렬
-                when(promiseType){
+                // promiseType == BEFORE 인 것만 정렬
+                when (promiseType) {
                     // 예정된 약속은 오름차순 정렬
                     PromiseType.BEFORE -> promiseFindDtos.sortBy { it.endTime }
                     // 종료된 약속은 내림차순 정렬

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -69,7 +69,13 @@ class PromiseReadUseCase(
             }
 
             val action: (Entry<PromiseType, MutableList<PromiseFindDto>>) -> Unit = { (promiseType, promiseFindDtos) ->
-                promiseFindDtos.sortBy { it.endTime }
+                //promiseType == BEFORE 인 것만 정렬
+                when(promiseType){
+                    // 예정된 약속은 오름차순 정렬
+                    PromiseType.BEFORE -> promiseFindDtos.sortBy { it.endTime }
+                    // 종료된 약속은 내림차순 정렬
+                    else -> promiseFindDtos.sortByDescending { it.endTime }
+                }
             }
             promiseSplitByPromiseTypeDto.forEach(action)
         }
@@ -119,7 +125,7 @@ class PromiseReadUseCase(
             }
 
             val promiseImagesUrls = promiseImageAdapter.findAllByPromiseId(promise.id!!)
-                .sortedByDescending { it.createdAt }
+                .sortedBy { it.createdAt }
                 .map { it.uri }
 
             val timeOverLocations = promiseUsers.mapNotNull { promiseUser ->


### PR DESCRIPTION
## 개요
- close #183 

## 작업사항
- 약속 상세 조회 정렬 기준을 변경했습니다.

## 변경로직
- BEFORE -> 오름차순, END -> 내림차순