### PR TITLE
[DPMBE-118]이메일 허용 안했을때 발생하는 문제 해결

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/response/OauthUserInfoResponse.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/dto/response/OauthUserInfoResponse.kt
@@ -3,7 +3,6 @@ package com.depromeet.whatnow.api.auth.dto.response
 import com.depromeet.whatnow.api.auth.helper.OauthUserInfoDto
 
 data class OauthUserInfoResponse(
-    val email: String?,
     val profileImage: String,
     val isDefaultImage: Boolean,
     val nickname: String,
@@ -11,7 +10,7 @@ data class OauthUserInfoResponse(
 
     companion object {
         fun from(oauthUserInfoDto: OauthUserInfoDto): OauthUserInfoResponse {
-            return OauthUserInfoResponse(oauthUserInfoDto.email, oauthUserInfoDto.profileImage, oauthUserInfoDto.isDefaultImage, oauthUserInfoDto.username)
+            return OauthUserInfoResponse(oauthUserInfoDto.profileImage, oauthUserInfoDto.isDefaultImage, oauthUserInfoDto.username)
         }
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/KakaoOauthHelper.kt
@@ -41,7 +41,7 @@ class KakaoOauthHelper(
     fun getUserInfo(oauthAccessToken: String): OauthUserInfoDto {
         val response = kakaoInfoClient.kakaoUserInfo(BEARER + oauthAccessToken)
         val kakaoAccount: KakaoInformationResponse.KakaoAccount = response.kakaoAccount
-        return OauthUserInfoDto(response.id, kakaoAccount.profile.profileImageUrl, kakaoAccount.profile.isDefaultImage, kakaoAccount.profile.nickname, kakaoAccount.email, OauthProvider.KAKAO)
+        return OauthUserInfoDto(response.id, kakaoAccount.profile.profileImageUrl, kakaoAccount.profile.isDefaultImage, kakaoAccount.profile.nickname, OauthProvider.KAKAO)
     }
 
     fun getOIDCDecodePayload(token: String): OIDCDecodePayload {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/OauthUserInfoDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/auth/helper/OauthUserInfoDto.kt
@@ -8,7 +8,6 @@ data class OauthUserInfoDto(
     val profileImage: String,
     val isDefaultImage: Boolean,
     val username: String,
-    val email: String?,
     val oauthProvider: OauthProvider,
 ) {
     fun toOauthInfo(): OauthInfo {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtOIDCHelper.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/JwtOIDCHelper.kt
@@ -52,7 +52,6 @@ class JwtOIDCHelper {
             body.issuer,
             body.audience,
             body.subject,
-            body["email", String::class.java],
         )
     }
 

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/OIDCDecodePayload.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/config/jwt/OIDCDecodePayload.kt
@@ -11,5 +11,4 @@ data class OIDCDecodePayload(
     /** oauth provider account unique id  */
     val sub: String,
 
-    val email: String,
 )

--- a/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
+++ b/Whatnow-Infrastructure/src/main/kotlin/com/depromeet/whatnow/api/dto/KakaoInformationResponse.kt
@@ -18,7 +18,6 @@ data class KakaoInformationResponse(
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class KakaoAccount(
         val profile: Profile,
-        val email: String?,
     ) {
 
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)

--- a/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoInfoClientTest.kt
+++ b/Whatnow-Infrastructure/src/test/kotlin/com/depromeet/whatnow/api/KakaoInfoClientTest.kt
@@ -40,7 +40,6 @@ class KakaoInfoClientTest {
                 ),
         )
         var response = kakaoInfoClient.kakaoUserInfo("accessToken")
-        assertEquals(response.kakaoAccount.email, "sample@sample.com")
         assertEquals(response.kakaoAccount.profile.profileImageUrl, "http://yyy.kakao.com/dn/.../img_640x640.jpg")
         assertEquals(response.kakaoAccount.profile.isDefaultImage, false)
     }


### PR DESCRIPTION
## 개요
- close #191 

## 작업사항
- 이메일 제공 권한이 필수가 아니라 옵션이라, 허용안했을때 값이 안들어와 발생하는 문제를 해결하였습니다.
- 이메일에 대한 값을 따로 사용하지 않아 모두 제거하였습니다.