### PR TITLE
[DPMBE-120] 약속 초대 코드를 생성한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/WhatnowApiApplication.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/WhatnowApiApplication.kt
@@ -3,9 +3,11 @@ package com.depromeet.whatnow
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.web.filter.ForwardedHeaderFilter
 
 @SpringBootApplication
+@EnableAspectJAutoProxy
 class WhatnowApiApplication {
     companion object {
         @JvmStatic

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
@@ -3,6 +3,7 @@ package com.depromeet.whatnow.api.example.controller
 import com.depromeet.whatnow.annotation.ApiErrorCodeExample
 import com.depromeet.whatnow.api.config.kakao.KakaoKauthErrorCode
 import com.depromeet.whatnow.domains.image.exception.ImageErrorCode
+import com.depromeet.whatnow.domains.invitecode.exception.InviteCodeErrorCode
 import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
 import com.depromeet.whatnow.domains.promise.exception.PromiseErrorCode
 import com.depromeet.whatnow.domains.promiseuser.exception.PromiseUserErrorCode
@@ -57,4 +58,10 @@ class ExampleController() {
     @Operation(summary = "약속 참여 관련 에러코드 나열")
     @ApiErrorCodeExample(PromiseUserErrorCode::class)
     fun promiseUserErrorCode() {}
+
+
+    @GetMapping("/invite-codes")
+    @Operation(summary = "약속 초대 코드 에러코드 나열")
+    @ApiErrorCodeExample(InviteCodeErrorCode::class)
+    fun inviteCodeErrorCode() {}
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/example/controller/ExampleController.kt
@@ -59,7 +59,6 @@ class ExampleController() {
     @ApiErrorCodeExample(PromiseUserErrorCode::class)
     fun promiseUserErrorCode() {}
 
-
     @GetMapping("/invite-codes")
     @Operation(summary = "약속 초대 코드 에러코드 나열")
     @ApiErrorCodeExample(InviteCodeErrorCode::class)

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -6,6 +6,7 @@ import com.depromeet.whatnow.api.promise.dto.PromiseDetailDto
 import com.depromeet.whatnow.api.promise.dto.PromiseDto
 import com.depromeet.whatnow.api.promise.dto.PromiseFindDto
 import com.depromeet.whatnow.api.promise.dto.PromiseRequest
+import com.depromeet.whatnow.api.promise.usecase.InviteCodeReadUseCase
 import com.depromeet.whatnow.api.promise.usecase.PromiseReadUseCase
 import com.depromeet.whatnow.api.promise.usecase.PromiseRegisterUseCase
 import com.depromeet.whatnow.common.vo.PlaceVo
@@ -33,6 +34,7 @@ import java.time.YearMonth
 class PromiseController(
     val promiseRegisterUseCase: PromiseRegisterUseCase,
     val promiseReadUseCase: PromiseReadUseCase,
+    val inviteCodeReadUseCase: InviteCodeReadUseCase,
 ) {
     @Deprecated("나의 약속 전부 조회", replaceWith = ReplaceWith("findPromiseByStatus"))
     @Operation(summary = "나의 약속 전부 조회", description = "유저의 약속 전부 조회 (단, 예정된 약속과 지난 약속을 구분해서 조회")
@@ -67,6 +69,12 @@ class PromiseController(
     @GetMapping("/promises/{promise-id}")
     fun findByPromiseId(@PathVariable(value = "promise-id") promiseId: Long): PromiseFindDto {
         return promiseReadUseCase.findByPromiseId(promiseId)
+    }
+
+    @Operation(summary = "promiseId 로 약속 초대 코드 조회", description = "promiseId 로 약속 초대 코드 조회하기")
+    @GetMapping("/promises/{promise-id}/invite-codes")
+    fun findInviteCodeByPromiseId(@PathVariable(value = "promise-id") promiseId: Long): String {
+        return inviteCodeReadUseCase.findInviteCodeByPromiseId(promiseId)
     }
 
     @Operation(summary = "약속(promise) 생성", description = "약속을 생성합니다.")

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseController.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.promise.controller
 
 import com.depromeet.whatnow.api.promise.annotation.RequiresMainUser
+import com.depromeet.whatnow.api.promise.dto.PromiseCreateDto
 import com.depromeet.whatnow.api.promise.dto.PromiseDetailDto
 import com.depromeet.whatnow.api.promise.dto.PromiseDto
 import com.depromeet.whatnow.api.promise.dto.PromiseFindDto
@@ -70,7 +71,7 @@ class PromiseController(
 
     @Operation(summary = "약속(promise) 생성", description = "약속을 생성합니다.")
     @PostMapping("/promises")
-    fun createPromise(@RequestBody promiseRequest: PromiseRequest): PromiseDto {
+    fun createPromise(@RequestBody promiseRequest: PromiseRequest): PromiseCreateDto {
         return promiseRegisterUseCase.createPromise(promiseRequest)
     }
 

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseCreateDto.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/dto/PromiseCreateDto.kt
@@ -1,0 +1,26 @@
+package com.depromeet.whatnow.api.promise.dto
+
+import com.depromeet.whatnow.common.vo.PlaceVo
+import com.depromeet.whatnow.domains.promise.domain.Promise
+import java.time.LocalDateTime
+
+data class PromiseCreateDto(
+    val title: String,
+    val mainUserId: Long,
+    val meetPlace: PlaceVo?,
+    val endTime: LocalDateTime,
+    val inviteCode: String,
+) {
+    companion object {
+        fun of(p: Promise?, inviteCode: String): PromiseCreateDto {
+            // Check if p is null and handle the null case appropriately
+            if (p == null) {
+                // Return a default or placeholder value for PromiseDto
+                return PromiseCreateDto("", 1L, null, LocalDateTime.now(), "")
+            }
+
+            // Process non-null Promise object
+            return PromiseCreateDto(p.title, p.mainUserId, p.meetPlace, p.endTime, inviteCode)
+        }
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/InviteCodeReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/InviteCodeReadUseCase.kt
@@ -1,0 +1,13 @@
+package com.depromeet.whatnow.api.promise.usecase
+
+import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
+
+@UseCase
+class InviteCodeReadUseCase(
+    val inviteCodeAdapter: InviteCodeAdapter,
+) {
+    fun findInviteCodeByPromiseId(promiseId: Long): String {
+        return inviteCodeAdapter.findByPromiseId(promiseId).inviteCode
+    }
+}

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseRegisterUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseRegisterUseCase.kt
@@ -29,8 +29,8 @@ class PromiseRegisterUseCase(
             ),
         )
         promise.createPromiseEvent()
-        val createInviteCode = inviteCodeDomainService.createInviteCode(promise.id!!)
-        return PromiseCreateDto.of(promise, createInviteCode)
+        val inviteCode = inviteCodeDomainService.upsertInviteCode(promise.id!!)
+        return PromiseCreateDto.of(promise, inviteCode)
     }
 
     fun updatePromiseMeetPlace(promiseId: Long, meetPlace: PlaceVo): PromiseDto {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseRegisterUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseRegisterUseCase.kt
@@ -1,9 +1,11 @@
 package com.depromeet.whatnow.api.promise.usecase
 
 import com.depromeet.whatnow.annotation.UseCase
+import com.depromeet.whatnow.api.promise.dto.PromiseCreateDto
 import com.depromeet.whatnow.api.promise.dto.PromiseDto
 import com.depromeet.whatnow.api.promise.dto.PromiseRequest
 import com.depromeet.whatnow.common.vo.PlaceVo
+import com.depromeet.whatnow.domains.invitecode.service.InviteCodeDomainService
 import com.depromeet.whatnow.domains.promise.adaptor.PromiseAdaptor
 import com.depromeet.whatnow.domains.promise.domain.Promise
 import com.depromeet.whatnow.domains.promise.service.PromiseDomainService
@@ -14,9 +16,10 @@ import java.time.LocalDateTime
 class PromiseRegisterUseCase(
     val promiseAdaptor: PromiseAdaptor,
     val promiseDomainService: PromiseDomainService,
+    val inviteCodeDomainService: InviteCodeDomainService,
 ) {
     @Transactional
-    fun createPromise(promiseRequest: PromiseRequest): PromiseDto {
+    fun createPromise(promiseRequest: PromiseRequest): PromiseCreateDto {
         val promise = promiseDomainService.save(
             Promise(
                 title = promiseRequest.title,
@@ -26,7 +29,8 @@ class PromiseRegisterUseCase(
             ),
         )
         promise.createPromiseEvent()
-        return PromiseDto.from(promise)
+        val createInviteCode = inviteCodeDomainService.createInviteCode(promise.id!!)
+        return PromiseCreateDto.of(promise, createInviteCode)
     }
 
     fun updatePromiseMeetPlace(promiseId: Long, meetPlace: PlaceVo): PromiseDto {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
@@ -31,6 +31,12 @@ class PromiseUserController(
         return promiseUserRecordUseCase.createPromiseUser(promiseId, userId, userLocation)
     }
 
+    @Operation(summary = "약속 코드로 약속 유저 생성", description = "약속 코드로 약속에 유저가 참여합니다.")
+    @PostMapping("/promises/users/join")
+    fun joinPromise(@RequestParam("invite-codes") inviteCode: String): PromiseUserDto {
+        return promiseUserRecordUseCase.createPromiseUserByInviteCode(inviteCode)
+    }
+
     @Operation(summary = "약속 id로 약속 유저(promiseUser) 조회", description = "약속ID 로 약속 유저를 조회합니다.")
     @GetMapping("/promises/{promiseId}/users")
     fun getPromiseUser(@PathVariable("promise-id") promiseId: Long): List<PromiseUserDto> {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
@@ -4,6 +4,7 @@ import com.depromeet.whatnow.api.promiseuser.dto.PromiseLocationDto
 import com.depromeet.whatnow.api.promiseuser.dto.PromiseUserDto
 import com.depromeet.whatnow.api.promiseuser.usecase.PromiseUserReadUseCase
 import com.depromeet.whatnow.api.promiseuser.usecase.PromiseUserRecordUseCase
+import com.depromeet.whatnow.common.aop.verify.InviteCodeLength
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUserType
 import io.swagger.v3.oas.annotations.Operation
@@ -33,7 +34,11 @@ class PromiseUserController(
 
     @Operation(summary = "약속 코드로 약속 유저 생성", description = "약속 코드로 약속에 유저가 참여합니다.")
     @PostMapping("/promises/users/join")
-    fun joinPromise(@RequestParam("invite-codes") inviteCode: String): PromiseUserDto {
+    fun joinPromise(
+        @InviteCodeLength
+        @RequestParam("invite-codes")
+        inviteCode: String,
+    ): PromiseUserDto {
         return promiseUserRecordUseCase.createPromiseUserByInviteCode(inviteCode)
     }
 

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
@@ -63,8 +63,4 @@ class PromiseUserRecordUseCase(
 
         return promiseUsers.map(PromiseLocationDto::from)
     }
-
-    fun createInviteCode(promiseId: Long): String {
-        return inviteCodeDomainService.createInviteCode(promiseId)
-    }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
@@ -6,7 +6,7 @@ import com.depromeet.whatnow.api.promiseuser.dto.PromiseUserDto
 import com.depromeet.whatnow.common.aop.verify.ActivePromise
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.security.SecurityUtils
-import com.depromeet.whatnow.domains.invitecode.service.InviteCodeDomainService
+import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
 import com.depromeet.whatnow.domains.progresshistory.domain.PromiseProgress.DEFAULT
 import com.depromeet.whatnow.domains.promise.exception.PromiseNotParticipateException
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUser
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class PromiseUserRecordUseCase(
     val promiseUserDomainService: PromiseUserDomainService,
-    val inviteCodeDomainService: InviteCodeDomainService,
+    val inviteCodeAdapter: InviteCodeAdapter,
 ) {
     @Transactional
     fun createPromiseUser(promiseId: Long, userId: Long, userLocation: CoordinateVo): PromiseUserDto {
@@ -62,5 +62,20 @@ class PromiseUserRecordUseCase(
             .map { if (it.userId == promiseUser.userId) promiseUser else it }
 
         return promiseUsers.map(PromiseLocationDto::from)
+    }
+
+    @Transactional
+    fun createPromiseUserByInviteCode(inviteCode: String): PromiseUserDto {
+        val userId = SecurityUtils.currentUserId
+        val promiseId = inviteCodeAdapter.findByInviteCode(inviteCode).promiseId
+        return PromiseUserDto.of(
+            promiseUserDomainService.createPromiseUser(
+                PromiseUser(
+                    promiseId = promiseId,
+                    userId = userId,
+                ),
+            ),
+            progress = DEFAULT,
+        )
     }
 }

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/usecase/PromiseUserRecordUseCase.kt
@@ -6,6 +6,7 @@ import com.depromeet.whatnow.api.promiseuser.dto.PromiseUserDto
 import com.depromeet.whatnow.common.aop.verify.ActivePromise
 import com.depromeet.whatnow.common.vo.CoordinateVo
 import com.depromeet.whatnow.config.security.SecurityUtils
+import com.depromeet.whatnow.domains.invitecode.service.InviteCodeDomainService
 import com.depromeet.whatnow.domains.progresshistory.domain.PromiseProgress.DEFAULT
 import com.depromeet.whatnow.domains.promise.exception.PromiseNotParticipateException
 import com.depromeet.whatnow.domains.promiseuser.domain.PromiseUser
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class PromiseUserRecordUseCase(
     val promiseUserDomainService: PromiseUserDomainService,
+    val inviteCodeDomainService: InviteCodeDomainService,
 ) {
     @Transactional
     fun createPromiseUser(promiseId: Long, userId: Long, userLocation: CoordinateVo): PromiseUserDto {
@@ -60,5 +62,9 @@ class PromiseUserRecordUseCase(
             .map { if (it.userId == promiseUser.userId) promiseUser else it }
 
         return promiseUsers.map(PromiseLocationDto::from)
+    }
+
+    fun createInviteCode(promiseId: Long): String {
+        return inviteCodeDomainService.createInviteCode(promiseId)
     }
 }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseControllerTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/controller/PromiseControllerTest.kt
@@ -1,6 +1,7 @@
 package com.depromeet.whatnow.api.promise.controller
 
 import com.depromeet.whatnow.api.image.controller.ImageController
+import com.depromeet.whatnow.api.promise.usecase.InviteCodeReadUseCase
 import com.depromeet.whatnow.api.promise.usecase.PromiseReadUseCase
 import com.depromeet.whatnow.api.promise.usecase.PromiseRegisterUseCase
 import org.junit.jupiter.api.Test
@@ -22,6 +23,9 @@ class PromiseControllerTest {
 
     @MockBean
     lateinit var promiseRegisterUseCase: PromiseRegisterUseCase
+
+    @MockBean
+    lateinit var inviteCodeReadUseCase: InviteCodeReadUseCase
 
     @Autowired
     lateinit var mockMvc: MockMvc

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
@@ -1,10 +1,13 @@
 package com.depromeet.whatnow.domains.invitecode.service
 
+import com.depromeet.whatnow.consts.INVITE_CODE_EXPIRED_TIME
 import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
+import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import kotlin.test.assertNotEquals
 
@@ -21,15 +24,37 @@ class InviteCodeDomainServiceTest() {
     }
 
     @Test
-    fun `약속 id로 매번 유니크한 초대 코드를 생성한다`() {
+    fun `사전에 저장된 경우 약속 id로 초대 코드를 생성하지 않고 기존 값을 반환한다`() {
         // given
         val promiseId1 = 1L
         val promiseId2 = 2L
+
+        `when`(inviteCodeAdapter.findByPromiseId(promiseId1)).thenReturn(InviteCodeRedisEntity(promiseId1, "code1", INVITE_CODE_EXPIRED_TIME))
+        `when`(inviteCodeAdapter.findByPromiseId(promiseId2)).thenReturn(InviteCodeRedisEntity(promiseId2, "code2", INVITE_CODE_EXPIRED_TIME))
+
         // when
-        val code1 = inviteCodeDomainService.createInviteCode(promiseId1)
-        val code2 = inviteCodeDomainService.createInviteCode(promiseId2)
+        val code1 = inviteCodeDomainService.upsertInviteCode(promiseId1)
+        val code2 = inviteCodeDomainService.upsertInviteCode(promiseId2)
+
         // then
-        print("code1 : $code1, code2 : $code2")
+        assertNotEquals(code1, code2)
+    }
+
+    @Test
+    fun `저장되지 않은 경우 약속 id로 매번 유니크한 초대 코드를 생성한다`() {
+        // given
+        val promiseId1 = 1L
+        val promiseId2 = 2L
+
+        // Mock the behavior of inviteCodeAdapter.findByPromiseId to use inviteCodeRepository
+        `when`(inviteCodeAdapter.findByPromiseId(promiseId1)).thenCallRealMethod()
+        `when`(inviteCodeAdapter.findByPromiseId(promiseId2)).thenCallRealMethod()
+
+        // when
+        val code1 = inviteCodeDomainService.upsertInviteCode(promiseId1)
+        val code2 = inviteCodeDomainService.upsertInviteCode(promiseId2)
+
+        // then
         assertNotEquals(code1, code2)
     }
 }

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
@@ -1,0 +1,35 @@
+package com.depromeet.whatnow.domains.invitecode.service
+
+import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class InviteCodeDomainServiceTest(
+){
+    @Mock
+    private lateinit var inviteCodeAdapter: InviteCodeAdapter
+
+    private lateinit var inviteCodeDomainService: InviteCodeDomainService
+
+    @BeforeEach
+    fun setUp(){
+        inviteCodeDomainService = InviteCodeDomainService(inviteCodeAdapter)
+    }
+    @Test
+    fun `약속 id로 매번 유니크한 초대 코드를 생성한다`(){
+    //given
+        val promiseId1 = 1L
+        val promiseId2 = 2L
+        //when
+        val code1 = inviteCodeDomainService.createInviteCode(promiseId1)
+        val code2 = inviteCodeDomainService.createInviteCode(promiseId2)
+        //then
+        print("code1 : $code1, code2 : $code2")
+        assertNotEquals(code1, code2)
+    }
+}

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainServiceTest.kt
@@ -1,34 +1,34 @@
 package com.depromeet.whatnow.domains.invitecode.service
 
 import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.test.assertNotEquals
 
 @ExtendWith(MockitoExtension::class)
-class InviteCodeDomainServiceTest(
-){
+class InviteCodeDomainServiceTest() {
     @Mock
     private lateinit var inviteCodeAdapter: InviteCodeAdapter
 
     private lateinit var inviteCodeDomainService: InviteCodeDomainService
 
     @BeforeEach
-    fun setUp(){
+    fun setUp() {
         inviteCodeDomainService = InviteCodeDomainService(inviteCodeAdapter)
     }
+
     @Test
-    fun `약속 id로 매번 유니크한 초대 코드를 생성한다`(){
-    //given
+    fun `약속 id로 매번 유니크한 초대 코드를 생성한다`() {
+        // given
         val promiseId1 = 1L
         val promiseId2 = 2L
-        //when
+        // when
         val code1 = inviteCodeDomainService.createInviteCode(promiseId1)
         val code2 = inviteCodeDomainService.createInviteCode(promiseId2)
-        //then
+        // then
         print("code1 : $code1, code2 : $code2")
         assertNotEquals(code1, code2)
     }

--- a/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
+++ b/Whatnow-Common/src/main/kotlin/com/depromeet/whatnow/consts/WhatNowStatic.kt
@@ -35,8 +35,9 @@ const val NCP_LOCAL_SEARCH_DISPLAY_COUNT = 10
 const val IMAGE_DOMAIN = "https://image.whatnow.kr"
 const val ASSERT_IMAGE_DOMAIN = "https://image.whatnow.kr/assert"
 const val USER_DEFAULT_PROFILE_IMAGE = "https://image.whatnow.kr/assert/users/default.svg"
-
+const val INVITE_CODE_EXPIRED_TIME = 86400L
 const val REDIS_EXPIRE_EVENT_PATTERN = "__keyevent@*__:expired"
+const val INVITE_CODE_LENGTH = 13
 
 val SWAGGER_PATTERNS = arrayOf(
     "/swagger-resources/**",

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/InviteCodeLength.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/InviteCodeLength.kt
@@ -1,0 +1,5 @@
+package com.depromeet.whatnow.common.aop.verify
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class InviteCodeLength

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/InviteCodeLengthValidationAspect.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/common/aop/verify/InviteCodeLengthValidationAspect.kt
@@ -1,0 +1,22 @@
+package com.depromeet.whatnow.common.aop.verify
+
+import com.depromeet.whatnow.domains.invitecode.exception.InviteCodeFormatMismatchException
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class InviteCodeLengthValidationAspect {
+    @Around("@annotation(com.depromeet.whatnow.common.aop.verify.InviteCodeLength)")
+    fun validateInviteCodeFormat(joinPoint: ProceedingJoinPoint): Any? {
+        val args = joinPoint.args
+        val inviteCode = args[0]
+        println("inviteCode: $inviteCode")
+        if (inviteCode is String && inviteCode.length != 13) {
+            throw InviteCodeFormatMismatchException.EXCEPTION
+        }
+        return joinPoint.proceed()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
@@ -1,14 +1,14 @@
-package com.depromeet.whatnow.domains.promiseactive.adapter
+package com.depromeet.whatnow.domains.invitecode.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
-import com.depromeet.whatnow.domains.invitecode.domain.PromiseActiveRedisEntity
+import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
 import com.depromeet.whatnow.domains.promiseactive.repository.PromiseActiveRepository
 
 @Adapter
-class PromiseActiveAdapter(
+class InviteCodeAdapter(
     val promiseActiveRepository: PromiseActiveRepository,
 ) {
-    fun save(promiseActiveRedisEntity: PromiseActiveRedisEntity): PromiseActiveRedisEntity {
+    fun save(promiseActiveRedisEntity: InviteCodeRedisEntity): InviteCodeRedisEntity {
         return promiseActiveRepository.save(promiseActiveRedisEntity)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
@@ -2,7 +2,9 @@ package com.depromeet.whatnow.domains.invitecode.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
 import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
+import com.depromeet.whatnow.domains.invitecode.exception.InviteCodeNotFoundException
 import com.depromeet.whatnow.domains.invitecode.repository.InviteCodeRepository
+import org.springframework.data.repository.findByIdOrNull
 
 @Adapter
 class InviteCodeAdapter(
@@ -10,5 +12,8 @@ class InviteCodeAdapter(
 ) {
     fun save(inviteCodeRedisEntity: InviteCodeRedisEntity): InviteCodeRedisEntity {
         return inviteCodeRepository.save(inviteCodeRedisEntity)
+    }
+    fun findByPromiseId(promiseId: Long): InviteCodeRedisEntity {
+        return inviteCodeRepository.findByIdOrNull(promiseId) ?: throw InviteCodeNotFoundException.EXCEPTION
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
@@ -16,4 +16,8 @@ class InviteCodeAdapter(
     fun findByPromiseId(promiseId: Long): InviteCodeRedisEntity {
         return inviteCodeRepository.findByIdOrNull(promiseId) ?: throw InviteCodeNotFoundException.EXCEPTION
     }
+
+    fun findByInviteCode(inviteCode: String): InviteCodeRedisEntity {
+        return inviteCodeRepository.findByInviteCode(inviteCode) ?: throw InviteCodeNotFoundException.EXCEPTION
+    }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/adapter/InviteCodeAdapter.kt
@@ -2,13 +2,13 @@ package com.depromeet.whatnow.domains.invitecode.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
 import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
-import com.depromeet.whatnow.domains.promiseactive.repository.PromiseActiveRepository
+import com.depromeet.whatnow.domains.invitecode.repository.InviteCodeRepository
 
 @Adapter
 class InviteCodeAdapter(
-    val promiseActiveRepository: PromiseActiveRepository,
+    val inviteCodeRepository: InviteCodeRepository,
 ) {
-    fun save(promiseActiveRedisEntity: InviteCodeRedisEntity): InviteCodeRedisEntity {
-        return promiseActiveRepository.save(promiseActiveRedisEntity)
+    fun save(inviteCodeRedisEntity: InviteCodeRedisEntity): InviteCodeRedisEntity {
+        return inviteCodeRepository.save(inviteCodeRedisEntity)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
@@ -1,16 +1,16 @@
 package com.depromeet.whatnow.domains.invitecode.domain
 
 import org.springframework.data.annotation.Id
-import org.springframework.data.mongodb.core.index.HashIndexed
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
+import org.springframework.data.redis.core.index.Indexed
 
 @RedisHash(value = "inviteCode")
 class InviteCodeRedisEntity(
     @Id
     var promiseId: Long,
 
-    @HashIndexed
+    @Indexed
     var inviteCode: String,
 
     @TimeToLive // TTL

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
@@ -1,0 +1,14 @@
+package com.depromeet.whatnow.domains.invitecode.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+@RedisHash(value = "inviteCode")
+class InviteCodeRedisEntity(
+    @Id
+    var key: String,
+
+    @TimeToLive // TTL
+    var ttl: Long,
+)

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/domain/InviteCodeRedisEntity.kt
@@ -1,13 +1,17 @@
 package com.depromeet.whatnow.domains.invitecode.domain
 
 import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.HashIndexed
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
 
 @RedisHash(value = "inviteCode")
 class InviteCodeRedisEntity(
     @Id
-    var key: String,
+    var promiseId: Long,
+
+    @HashIndexed
+    var inviteCode: String,
 
     @TimeToLive // TTL
     var ttl: Long,

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeDuplicateCreatedException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeDuplicateCreatedException.kt
@@ -1,10 +1,9 @@
 package com.depromeet.whatnow.domains.invitecode.exception
 
-import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeDuplicateCreatedException : WhatnowCodeException(
-    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+    InviteCodeErrorCode.INVITE_CODE_DUPLICATE_CREATED,
 ) {
     companion object {
         val EXCEPTION: WhatnowCodeException = InviteCodeDuplicateCreatedException()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeDuplicateCreatedException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeDuplicateCreatedException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.domains.invitecode.exception
+
+import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class InviteCodeDuplicateCreatedException : WhatnowCodeException(
+    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = InviteCodeDuplicateCreatedException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeErrorCode.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeErrorCode.kt
@@ -1,0 +1,32 @@
+package com.depromeet.whatnow.domains.invitecode.exception
+
+import com.depromeet.whatnow.annotation.ExplainError
+import com.depromeet.whatnow.consts.BAD_REQUEST
+import com.depromeet.whatnow.dto.ErrorReason
+import com.depromeet.whatnow.exception.BaseErrorCode
+import java.util.Objects
+
+enum class InviteCodeErrorCode(val status: Int, val code: String, val reason: String) : BaseErrorCode {
+    @ExplainError("약속에 중복된 초대코드를 생성한 경우")
+    INVITE_CODE_DUPLICATE_CREATED(BAD_REQUEST, "INVITE_CODE_400_1", "중복된 초대코르를 생성하셨습니다."),
+
+    @ExplainError("조회한 초대코드가 존재하지 않는 경우")
+    INVITE_CODE_NOT_FOUND(BAD_REQUEST, "INVITE_CODE_400_2", "조회하신 초대코드가 조회되지 않습니다. 다시 시도하여 주십시오."),
+
+    @ExplainError("조회한 초대코드의 형식이 일치하지 않는 경우")
+    INVITE_CODE_FORMAT_MISMATCH(BAD_REQUEST, "INVITE_CODE_400_3", "조회한 초대 코드의 형식이 일치하지 않습니다."),
+
+    @ExplainError("조회한 초대코드가 만료된 경우")
+    INVITE_CODE_EXPIRED(BAD_REQUEST, "INVITE_CODE_400_4", "초대코드가 만료되었습니다, 다시 생성하여 주세요."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() { return ErrorReason(status, code, reason) }
+
+    override val explainError: String
+        get() {
+            val field = this.javaClass.getField(name)
+            val annotation = field.getAnnotation(ExplainError::class.java)
+            return if (Objects.nonNull(annotation)) annotation.value else reason
+        }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.domains.invitecode.exception
 
-import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeExpiredException : WhatnowCodeException(

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.domains.invitecode.exception
+
+import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class InviteCodeExpiredException : WhatnowCodeException(
+    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = InviteCodeExpiredException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeExpiredException.kt
@@ -4,7 +4,7 @@ import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErr
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeExpiredException : WhatnowCodeException(
-    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+    InviteCodeErrorCode.INVITE_CODE_EXPIRED,
 ) {
     companion object {
         val EXCEPTION: WhatnowCodeException = InviteCodeExpiredException()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.domains.invitecode.exception
+
+import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class InviteCodeFormatMismatchException : WhatnowCodeException(
+    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = InviteCodeFormatMismatchException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
@@ -4,7 +4,7 @@ import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErr
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeFormatMismatchException : WhatnowCodeException(
-    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+    InviteCodeErrorCode.INVITE_CODE_FORMAT_MISMATCH,
 ) {
     companion object {
         val EXCEPTION: WhatnowCodeException = InviteCodeFormatMismatchException()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeFormatMismatchException.kt
@@ -1,6 +1,5 @@
 package com.depromeet.whatnow.domains.invitecode.exception
 
-import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeFormatMismatchException : WhatnowCodeException(

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.depromeet.whatnow.domains.invitecode.exception
+
+import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class InviteCodeNotFoundException : WhatnowCodeException(
+    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = InviteCodeNotFoundException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/exception/InviteCodeNotFoundException.kt
@@ -1,10 +1,9 @@
 package com.depromeet.whatnow.domains.invitecode.exception
 
-import com.depromeet.whatnow.domains.progresshistory.exception.PromiseHistoryErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class InviteCodeNotFoundException : WhatnowCodeException(
-    PromiseHistoryErrorCode.PROMISE_PROGRESS_IS_SAME,
+    InviteCodeErrorCode.INVITE_CODE_NOT_FOUND,
 ) {
     companion object {
         val EXCEPTION: WhatnowCodeException = InviteCodeNotFoundException()

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/repository/InviteCodeRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/repository/InviteCodeRepository.kt
@@ -3,4 +3,6 @@ package com.depromeet.whatnow.domains.invitecode.repository
 import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
 import org.springframework.data.repository.CrudRepository
 
-interface InviteCodeRepository : CrudRepository<InviteCodeRedisEntity, String>
+interface InviteCodeRepository : CrudRepository<InviteCodeRedisEntity, Long> {
+    fun findByInviteCode(inviteCode: String): InviteCodeRedisEntity?
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/repository/InviteCodeRepository.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/repository/InviteCodeRepository.kt
@@ -1,0 +1,6 @@
+package com.depromeet.whatnow.domains.invitecode.repository
+
+import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
+import org.springframework.data.repository.CrudRepository
+
+interface InviteCodeRepository : CrudRepository<InviteCodeRedisEntity, String>

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
@@ -19,7 +19,7 @@ class InviteCodeDomainService(
         val inviteCode = generateInviteCodeFromHash(hashedPromiseId)
 
         // redis에 초대 코드 저장 및 만료 시간 지정 / 24 hour
-        saveInviteCodeToRedis(inviteCode, INVITE_CODE_EXPIRED_TIME)
+        saveInviteCodeToRedis(promiseId, inviteCode, INVITE_CODE_EXPIRED_TIME)
 
         return inviteCode
     }
@@ -38,8 +38,8 @@ class InviteCodeDomainService(
         return sb.substring(0, min(INVITE_CODE_LENGTH, sb.length))
     }
 
-    private fun saveInviteCodeToRedis(inviteCode: String, expirationHours: Long) {
-        val redisEntity = InviteCodeRedisEntity(inviteCode, expirationHours)
+    private fun saveInviteCodeToRedis(promiseId: Long, inviteCode: String, expirationHours: Long) {
+        val redisEntity = InviteCodeRedisEntity(promiseId, inviteCode, expirationHours)
         inviteCodeAdapter.save(redisEntity)
     }
 }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
@@ -18,7 +18,7 @@ class InviteCodeDomainService(
         val hashedPromiseId = hashStringWithSHA256(promiseIdString)
         val inviteCode = generateInviteCodeFromHash(hashedPromiseId)
 
-        // Save the code to Redis with an expiration time
+        // redis에 초대 코드 저장 및 만료 시간 지정 / 24 hour
         saveInviteCodeToRedis(inviteCode, INVITE_CODE_EXPIRED_TIME)
 
         return inviteCode
@@ -32,7 +32,7 @@ class InviteCodeDomainService(
     private fun generateInviteCodeFromHash(hashBytes: ByteArray): String {
         val sb = StringBuilder()
         for (b in hashBytes) {
-            // Convert hash bytes to hexadecimal string
+            // Convert hash bytes -> hexadecimal string
             sb.append(String.format("%02x", b))
         }
         return sb.substring(0, min(INVITE_CODE_LENGTH, sb.length))

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/invitecode/service/InviteCodeDomainService.kt
@@ -1,0 +1,45 @@
+package com.depromeet.whatnow.domains.invitecode.service
+
+import com.depromeet.whatnow.annotation.DomainService
+import com.depromeet.whatnow.consts.INVITE_CODE_EXPIRED_TIME
+import com.depromeet.whatnow.consts.INVITE_CODE_LENGTH
+import com.depromeet.whatnow.domains.invitecode.adapter.InviteCodeAdapter
+import com.depromeet.whatnow.domains.invitecode.domain.InviteCodeRedisEntity
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import kotlin.math.min
+
+@DomainService
+class InviteCodeDomainService(
+    val inviteCodeAdapter: InviteCodeAdapter,
+) {
+    fun createInviteCode(promiseId: Long): String {
+        val promiseIdString = promiseId.toString()
+        val hashedPromiseId = hashStringWithSHA256(promiseIdString)
+        val inviteCode = generateInviteCodeFromHash(hashedPromiseId)
+
+        // Save the code to Redis with an expiration time
+        saveInviteCodeToRedis(inviteCode, INVITE_CODE_EXPIRED_TIME)
+
+        return inviteCode
+    }
+
+    private fun hashStringWithSHA256(input: String): ByteArray {
+        val md = MessageDigest.getInstance("SHA-256")
+        return md.digest(input.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun generateInviteCodeFromHash(hashBytes: ByteArray): String {
+        val sb = StringBuilder()
+        for (b in hashBytes) {
+            // Convert hash bytes to hexadecimal string
+            sb.append(String.format("%02x", b))
+        }
+        return sb.substring(0, min(INVITE_CODE_LENGTH, sb.length))
+    }
+
+    private fun saveInviteCodeToRedis(inviteCode: String, expirationHours: Long) {
+        val redisEntity = InviteCodeRedisEntity(inviteCode, expirationHours)
+        inviteCodeAdapter.save(redisEntity)
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/adapter/PromiseActiveAdapter.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/adapter/PromiseActiveAdapter.kt
@@ -1,7 +1,7 @@
 package com.depromeet.whatnow.domains.promiseactive.adapter
 
 import com.depromeet.whatnow.annotation.Adapter
-import com.depromeet.whatnow.domains.invitecode.domain.PromiseActiveRedisEntity
+import com.depromeet.whatnow.domains.promiseactive.domain.PromiseActiveRedisEntity
 import com.depromeet.whatnow.domains.promiseactive.repository.PromiseActiveRepository
 
 @Adapter

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/PromiseActivationEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/PromiseActivationEventHandler.kt
@@ -1,9 +1,9 @@
 package com.depromeet.whatnow.events.handler
 
 import com.depromeet.whatnow.annotation.Handler
+import com.depromeet.whatnow.domains.invitecode.domain.PromiseActiveRedisEntity
 import com.depromeet.whatnow.domains.promise.service.PromiseDomainService
 import com.depromeet.whatnow.domains.promiseactive.adapter.PromiseActiveAdapter
-import com.depromeet.whatnow.domains.promiseactive.domain.PromiseActiveRedisEntity
 import com.depromeet.whatnow.events.domainEvent.PromiseRegisterEvent
 import org.springframework.scheduling.annotation.Async
 import org.springframework.transaction.event.TransactionPhase

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/PromiseActivationEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/PromiseActivationEventHandler.kt
@@ -1,9 +1,9 @@
 package com.depromeet.whatnow.events.handler
 
 import com.depromeet.whatnow.annotation.Handler
-import com.depromeet.whatnow.domains.invitecode.domain.PromiseActiveRedisEntity
 import com.depromeet.whatnow.domains.promise.service.PromiseDomainService
 import com.depromeet.whatnow.domains.promiseactive.adapter.PromiseActiveAdapter
+import com.depromeet.whatnow.domains.promiseactive.domain.PromiseActiveRedisEntity
 import com.depromeet.whatnow.events.domainEvent.PromiseRegisterEvent
 import org.springframework.scheduling.annotation.Async
 import org.springframework.transaction.event.TransactionPhase

--- a/Whatnow-Domain/src/main/resources/application-domain.yml
+++ b/Whatnow-Domain/src/main/resources/application-domain.yml
@@ -31,6 +31,7 @@ logging:
     com.zaxxer.hikari: TRACE
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
+    org.springframework.aop: DEBUG
 ---
 spring:
   config:


### PR DESCRIPTION
## 개요
- close #201 

## 작업사항
- 약속이 생성되면 Redis에 promiseId를 SHA-256 으로 암호화 해서 겹치지 않는 고유의 값을 13자리로 slice했습니다.
Line 의 초대 코드 생성을 보면 13자리라서 참고했습니다.
![image](https://github.com/depromeet/Whatnow-Api/assets/54030889/4842adb2-57cb-4c2f-bab9-80411bf17ff0)
실제 업로드 된 Redis 및 DB 확인했습니다.

- 16진수 13자리  초대코드인지 검증 로직 구현

ps) `ProceedingJoinPoint is only supported for around advice` 를 보면 AOP할때는 ProceedingJointPoint 쓸거면 무조건 Around 써야합니다.



## 변경로직

- 기존 save 로직에서 고유한 초대 코드 생성을 위해서 upsert 형태로 바꾸었습니다. redis는 한 key 에 2개의 값을 가질 수가 없어서 매번 update를 치는데 기존 값이 있으면 재사용하는 방식으로 결정했습니다.