### PR TITLE
[DPMBE-125] 인터렉션 발송 시 앱 알람이 꺼져있을때 푸시알림만 안보내도록 한다.

### DIFF
--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/InteractionFixedEventHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/InteractionFixedEventHandler.kt
@@ -10,6 +10,8 @@ import com.depromeet.whatnow.events.domainEvent.InteractionFixedEvent
 import mu.KLogger
 import mu.KotlinLogging
 import org.springframework.scheduling.annotation.Async
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -23,6 +25,7 @@ class InteractionFixedEventHandler(
     val logger: KLogger = KotlinLogging.logger {}
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(classes = [InteractionFixedEvent::class], phase = TransactionPhase.AFTER_COMMIT)
     fun handleInteractionFixedEvent(event: InteractionFixedEvent) {
         val promiseId = event.promiseId

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/InteractionHistoryRegisterHandler.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/events/handler/InteractionHistoryRegisterHandler.kt
@@ -39,21 +39,19 @@ class InteractionHistoryRegisterHandler(
         }
 
         val targetUser = userAdapter.queryUser(event.targetUserId)
-        if (!targetUser.fcmNotification.appAlarm) {
-            return
-        }
-
         val user = userAdapter.queryUser(event.userId)
 
         val data: MutableMap<String, String> = mutableMapOf()
         data["notificationType"] = NotificationType.INTERACTION.name
 
-        fcmService.sendMessageAsync(
-            targetUser.fcmNotification.fcmToken,
-            "이모지 투척!",
-            "from. $user.nickname",
-            data,
-        )
+        if (targetUser.fcmNotification.appAlarm) {
+            fcmService.sendMessageAsync(
+                targetUser.fcmNotification.fcmToken,
+                "이모지 투척!",
+                "from. $user.nickname",
+                data,
+            )
+        }
 
         notificationDomainService.saveForInteraction(event.promiseId, user.id!!, event.interactionType, targetUser.id!!)
     }


### PR DESCRIPTION
## 개요
- close #206 

## 작업사항
- 인터렉션 발송 시 해당 유저의 앱 알림이 false일때 return 시켜 notification 테이블에 데이터가 적재 안되는 문제를 해결하였습니다.
- 

## 변경로직
- 내용을 적어주세요.