### PR TITLE
[DPMBE-123] 트래킹 시작 시 해당 약속에 참여한 사람이 없다면 트래킹을 시작하지 않는다.

### DIFF
--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/listener/RedisExpireEventRedisMessageListener.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/listener/RedisExpireEventRedisMessageListener.kt
@@ -1,6 +1,9 @@
 package com.depromeet.whatnow.domains.promiseactive.listener
 
 import com.depromeet.whatnow.common.aop.event.Events
+import com.depromeet.whatnow.domains.promise.adaptor.PromiseAdaptor
+import com.depromeet.whatnow.domains.promiseactive.repository.PromiseActiveRepository
+import com.depromeet.whatnow.domains.promiseuser.adaptor.PromiseUserAdaptor
 import com.depromeet.whatnow.events.domainEvent.PromiseTimeEndEvent
 import com.depromeet.whatnow.events.domainEvent.PromiseTimeStartEvent
 import com.depromeet.whatnow.events.domainEvent.PromiseTrackingTimeEndEvent
@@ -10,7 +13,11 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
-class RedisExpireEventRedisMessageListener : MessageListener {
+class RedisExpireEventRedisMessageListener(
+    val promiseAdapter: PromiseAdaptor,
+    val promiseUserAdaptor: PromiseUserAdaptor,
+    val promiseActiveRepository: PromiseActiveRepository,
+) : MessageListener {
     @Transactional
     override fun onMessage(message: Message, pattern: ByteArray?) {
         val event = message.toString()
@@ -29,6 +36,16 @@ class RedisExpireEventRedisMessageListener : MessageListener {
     }
 
     private fun handlePromiseTimeStart(key: Long) {
+        val promiseUsers = promiseUserAdaptor.findByPromiseId(key)
+        if (promiseUsers.size < 2) {
+            promiseActiveRepository.findById("EXPIRE_EVENT_PROMISE_TIME_END_$key").ifPresent {
+                promiseActiveRepository.delete(it)
+            }
+            promiseActiveRepository.findById("EXPIRE_EVENT_TRACKING_TIME_START_$key").ifPresent {
+                promiseActiveRepository.delete(it)
+            }
+            return
+        }
         Events.raise(PromiseTimeStartEvent(key))
     }
 

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/listener/RedisExpireEventRedisMessageListener.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseactive/listener/RedisExpireEventRedisMessageListener.kt
@@ -36,8 +36,10 @@ class RedisExpireEventRedisMessageListener(
     }
 
     private fun handlePromiseTimeStart(key: Long) {
+        val promise = promiseAdapter.queryPromise(key)
         val promiseUsers = promiseUserAdaptor.findByPromiseId(key)
         if (promiseUsers.size < 2) {
+            promise.endPromise()
             promiseActiveRepository.findById("EXPIRE_EVENT_PROMISE_TIME_END_$key").ifPresent {
                 promiseActiveRepository.delete(it)
             }


### PR DESCRIPTION
## 개요
- close #203 

## 작업사항
- 트래킹 시작 시 해당 약속에 참여한 사람이 방장 혼자라면 트래킹을 할 필요 없이 약속을 종료처리하고,
- 약속종료, 트래킹종료 이벤트가 실행되지 않도록 redis에서 entity를 찾아 지워주는 작업 처리해두었습니당

## 변경로직
- 내용을 적어주세요.