### PR TITLE
[DPMBE-122] PromiseUser 중복 생성 방지한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promiseuser/controller/PromiseUserController.kt
@@ -43,7 +43,7 @@ class PromiseUserController(
     }
 
     @Operation(summary = "약속 id로 약속 유저(promiseUser) 조회", description = "약속ID 로 약속 유저를 조회합니다.")
-    @GetMapping("/promises/{promiseId}/users")
+    @GetMapping("/promises/{promise-id}/users")
     fun getPromiseUser(@PathVariable("promise-id") promiseId: Long): List<PromiseUserDto> {
         return promiseUserReadUseCase.findByPromiseId(promiseId)
     }

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserDuplicateException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserDuplicateException.kt
@@ -1,0 +1,11 @@
+package com.depromeet.whatnow.domains.promiseuser.exception
+
+import com.depromeet.whatnow.exception.WhatnowCodeException
+
+class PromiseUserDuplicateException : WhatnowCodeException(
+    PromiseUserErrorCode.PROMISE_USER_DUPLICATE,
+) {
+    companion object {
+        val EXCEPTION: WhatnowCodeException = PromiseUserDuplicateException()
+    }
+}

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserErrorCode.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserErrorCode.kt
@@ -16,9 +16,11 @@ enum class PromiseUserErrorCode(val status: Int, val code: String, val reason: S
     @ExplainError("종료된 약속에 참여하려는 경우 발생하는 오류")
     PROMISE_USER_FORBIDDEN(FORBIDDEN, "PROMISE_USER_403_1", "이미 종료된 약속 입니다."),
 
+    @ExplainError("약속유저 정보가 중복되는 경우")
+    PROMISE_USER_DUPLICATE(FORBIDDEN, "PROMISE_USER_403_2", "이미 참여한 약속입니다."),
+
     @ExplainError("약속유저 정보를 찾을 수 없는 경우")
     PROMISE_USER_NOT_FOUND(NOT_FOUND, "PROMISE_USER_404_1", "약속 유저 정보를 찾을 수 없습니다."),
-
     ;
 
     override val errorReason: ErrorReason

--- a/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserNotFoundException.kt
+++ b/Whatnow-Domain/src/main/kotlin/com/depromeet/whatnow/domains/promiseuser/exception/PromiseUserNotFoundException.kt
@@ -1,10 +1,9 @@
 package com.depromeet.whatnow.domains.promiseuser.exception
 
-import com.depromeet.whatnow.domains.user.exception.UserErrorCode
 import com.depromeet.whatnow.exception.WhatnowCodeException
 
 class PromiseUserNotFoundException : WhatnowCodeException(
-    UserErrorCode.USER_NOT_FOUND,
+    PromiseUserErrorCode.PROMISE_USER_NOT_FOUND,
 ) {
     companion object {
         val EXCEPTION: WhatnowCodeException = PromiseUserNotFoundException()


### PR DESCRIPTION
## 개요
- close #202

## 작업사항
- 생성시 2개 생성 못하게 막아두었습니다!

## 변경로직
- 기존의 에러 코드에 더불어 PromiseUserDuplicationException 추가했습니다.