### PR TITLE
[DPMBE-130] 상세조회 정렬 순서 최신순으로 변경한다

### DIFF
--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -97,7 +97,7 @@ class PromiseReadUseCase(
                     promise = promise,
                     users = participants,
                 )
-            }.sortedByDescending { it.endTime }
+            }.sortedBy { it.endTime }
     }
 
     fun findPromiseDetailByStatus(promiseType: PromiseType): List<PromiseDetailDto> {
@@ -144,7 +144,7 @@ class PromiseReadUseCase(
             )
         }
 
-        return result.sortedByDescending { it.endTime }
+        return result.sortedBy { it.endTime }
     }
 
     fun findPromiseActive(promiseId: Long): Boolean {
@@ -162,7 +162,7 @@ class PromiseReadUseCase(
 
     private fun findPromisesByUserId(userId: Long): List<Promise> {
         val promiseUsers = promiseUserAdaptor.findByUserId(userId)
-        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }.sortedByDescending { it.endTime }
+        return promiseUsers.map { promiseAdaptor.queryPromise(it.promiseId) }
     }
 
     fun findByPromiseId(promiseId: Long): PromiseFindDto {

--- a/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
+++ b/Whatnow-Api/src/main/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCase.kt
@@ -125,7 +125,7 @@ class PromiseReadUseCase(
             }
 
             val promiseImagesUrls = promiseImageAdapter.findAllByPromiseId(promise.id!!)
-                .sortedBy { it.createdAt }
+                .sortedByDescending { it.createdAt }
                 .map { it.uri }
 
             val timeOverLocations = promiseUsers.mapNotNull { promiseUser ->

--- a/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
+++ b/Whatnow-Api/src/test/kotlin/com/depromeet/whatnow/api/promise/usecase/PromiseReadUseCaseTest.kt
@@ -148,17 +148,17 @@ class PromiseReadUseCaseTest {
         // Then
         Assertions.assertEquals(2, result.size)
 
-        Assertions.assertEquals("Promise 2", result[0].title)
-        Assertions.assertEquals(promiseTime1, result[1].endTime)
+        Assertions.assertEquals("Promise 1", result[0].title)
+        Assertions.assertEquals(promiseTime1, result[0].endTime)
         Assertions.assertEquals(1, result[1].promiseUsers.size)
 
-        Assertions.assertEquals("Promise 1", result[1].title)
-        Assertions.assertEquals(promiseTime2, result[0].endTime)
+        Assertions.assertEquals("Promise 2", result[1].title)
+        Assertions.assertEquals(promiseTime2, result[1].endTime)
         Assertions.assertEquals(1, result[0].promiseUsers.size)
 
         // 약속 1번
-        Assertions.assertEquals(1234, result[1].promiseUsers[0].interactions[0].count)
+        Assertions.assertEquals(1234, result[0].promiseUsers[0].interactions[0].count)
         // 약속 2번
-        Assertions.assertEquals(2934, result[0].promiseUsers[0].interactions[0].count)
+        Assertions.assertEquals(2934, result[1].promiseUsers[0].interactions[0].count)
     }
 }


### PR DESCRIPTION
## 개요
- close #218

## 작업사항
- Detail에서 BEFORE (예정된 약속)을 빠른 약속 -> 느린 약속 오름 차순으로 다시 정렬했습니다.

## 변경로직
- 내용을 적어주세요.